### PR TITLE
Cleanup of the Contiki network layer configuration. Now using CONTIKI_WI...

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -14,10 +14,6 @@ ifeq ($(TARGET),)
   endif
 endif
 
-ifeq ($(UIP_CONF_IPV6),1)
-  CFLAGS += -DUIP_CONF_IPV6=1
-endif
-
 ifeq ($(DEFINES),)
   -include Makefile.$(TARGET).defines
   ifneq ($(DEFINES),)
@@ -104,6 +100,50 @@ else
   endif
   include $(target_makefile)
 endif
+
+# Include IPv6, IPv4, and/or Rime
+
+HAS_STACK = 0
+ifeq ($(CONTIKI_WITH_IPV4),1)
+  HAS_STACK = 1
+  CFLAGS += -DUIP_CONF_IPV4=1
+  MODULES += core/net/ipv4 core/net/ip
+endif
+
+ifeq ($(CONTIKI_WITH_RIME),1)
+  HAS_STACK = 1
+  CFLAGS += -DUIP_CONF_RIME=1 
+  MODULES += core/net/rime
+endif
+
+# Make IPv6 the default stack
+ifeq ($(HAS_STACK),0)
+ifneq ($(CONTIKI_WITH_IPV6),0)
+CONTIKI_WITH_IPV6 = 1
+endif
+endif
+
+ifeq ($(CONTIKI_WITH_IPV6),1)
+  CFLAGS += -DUIP_CONF_IPV6=1
+  ifneq ($(CONTIKI_WITH_RPL),0)
+    CFLAGS += -DUIP_CONF_IPV6_RPL=1
+    MODULES += core/net/rpl
+  endif # UIP_CONF_RPL
+  MODULES += core/net/ipv6 core/net/ip
+endif
+
+# No particular stack was specified. Compile all.
+#ifeq ($(HAS_STACK),0)
+#ifeq ($(PLATFORM_HAS_IPV6),1)
+#MODULES += core/net/ipv6 core/net/ip
+#endif
+#ifeq ($(PLATFORM_HAS_IPV4),1)
+#MODULES += core/net/ipv4 core/net/ip
+#endif
+#ifeq ($(PLATFORM_HAS_RIME),1)
+#MODULES += core/net/rime
+#endif
+#endif
 
 ifdef MODULES
   UNIQUEMODULES = $(call uniq,$(MODULES))

--- a/apps/shell/Makefile.shell
+++ b/apps/shell/Makefile.shell
@@ -1,19 +1,35 @@
-shell_src = shell.c shell-reboot.c \
-            shell-vars.c shell-ps.c shell-rime.c shell-sendtest.c \
+shell_src = shell.c shell-reboot.c shell-vars.c shell-ps.c \
             shell-blink.c shell-text.c shell-time.c \
-            shell-file.c shell-netfile.c shell-run.c \
-            shell-rime-ping.c shell-rime-sniff.c shell-rime-netcmd.c \
-            shell-rime-debug.c shell-rime-debug-runicast.c shell-coffee.c \
-            shell-wget.c shell-httpd.c shell-irc.c \
+            shell-file.c shell-run.c \
+            shell-coffee.c \
             shell-power.c \
-            shell-tcpsend.c shell-udpsend.c shell-ping.c shell-netstat.c \
-            shell-rime-sendcmd.c shell-download.c shell-rime-neighbors.c \
-            shell-rime-unicast.c \
             shell-base64.c \
-            shell-netperf.c shell-memdebug.c \
-	    shell-powertrace.c shell-collect-view.c shell-crc.c
+            shell-memdebug.c \
+	    shell-powertrace.c shell-crc.c
 shell_dsc = shell-dsc.c
+	    
+ifeq ($(CONTIKI_WITH_RIME),1)
+shell_src += shell-rime.c shell-sendtest.c shell-netfile.c \
+            shell-rime-ping.c shell-rime-sniff.c shell-rime-netcmd.c \
+            shell-rime-debug.c shell-rime-debug-runicast.c \
+            shell-rime-sendcmd.c shell-download.c shell-rime-neighbors.c \
+			shell-rime-unicast.c shell-netperf.c \
+			shell-collect-view.c 
+			
+APPS += collect-view
+include $(CONTIKI)/apps/collect-view/Makefile.collect-view
+endif
 
+ifeq ($(CONTIKI_WITH_IPV4),1)
+	SHELL_WITH_IP = 1
+endif
+ifeq ($(CONTIKI_WITH_IPV6),1)
+	SHELL_WITH_IP = 1
+endif
+
+ifeq ($(SHELL_WITH_IP),1)
+shell_src += shell-wget.c shell-httpd.c shell-irc.c \
+            shell-tcpsend.c shell-udpsend.c shell-ping.c shell-netstat.c
 APPS += webserver
 include $(CONTIKI)/apps/webserver/Makefile.webserver
 ifndef PLATFORM_BUILD
@@ -38,12 +54,10 @@ ifndef PLATFORM_BUILD
   override telnet_src = telnet.c
 endif
 
+endif
+
 APPS += powertrace
 include $(CONTIKI)/apps/powertrace/Makefile.powertrace
-
-
-APPS += collect-view
-include $(CONTIKI)/apps/collect-view/Makefile.collect-view
 
 ifeq ($(TARGET),sky)
   shell_src += shell-sky.c shell-exec.c

--- a/core/dev/slip.c
+++ b/core/dev/slip.c
@@ -96,7 +96,6 @@ slip_set_input_callback(void (*c)(void))
 /* slip_send: forward (IPv4) packets with {UIP_FW_NETIF(..., slip_send)}
  * was used in slip-bridge.c
  */
-//#if WITH_UIP
 uint8_t
 slip_send(void)
 {
@@ -125,7 +124,6 @@ slip_send(void)
 
   return UIP_FW_OK;
 }
-//#endif /* WITH_UIP */
 /*---------------------------------------------------------------------------*/
 uint8_t
 slip_write(const void *_ptr, int len)

--- a/cpu/6502/Makefile.6502
+++ b/cpu/6502/Makefile.6502
@@ -51,7 +51,7 @@ CONTIKI_SOURCEFILES += $(CTK) ctk-conio.c petsciiconv.c cfs-posix-dir.c \
                        $(CONTIKI_TARGET_SOURCEFILES) $(CONTIKI_CPU_SOURCEFILES) \
                        $(ETHERNET_SOURCEFILES)
 
-MODULES += core/ctk core/net/ip core/net/ipv4 core/net/ipv6
+MODULES += core/ctk
 
 # Set target-specific variable values
 ${addprefix $(OBJECTDIR)/,${call oname, $(ETHERNET_SOURCEFILES)}}: ASFLAGS += -D DYN_DRV=0

--- a/cpu/6502/ethconfig/Makefile
+++ b/cpu/6502/ethconfig/Makefile
@@ -2,4 +2,5 @@ CONTIKI_PROJECT = ethconfig
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/cpu/6502/ipconfig/Makefile
+++ b/cpu/6502/ipconfig/Makefile
@@ -2,4 +2,5 @@ CONTIKI_PROJECT = ipconfig
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/cpu/arm/at91sam7s/Makefile.at91sam7s
+++ b/cpu/arm/at91sam7s/Makefile.at91sam7s
@@ -76,7 +76,7 @@ CFLAGSNO = -I. -I$(CONTIKI)/core -I$(CONTIKI_CPU) -I$(CONTIKI_CPU)/loader \
 	   -I$(CONTIKI_CPU)/dbg-io \
            -I$(CONTIKI)/platform/$(TARGET) \
            ${addprefix -I,$(APPDIRS)} \
-           -DWITH_UIP -DWITH_ASCII -DMCK=$(MCK) \
+           -DWITH_ASCII -DMCK=$(MCK) \
            -Wall $(ARCH_FLAGS) -g -D SUBTARGET=$(SUBTARGET)
 
 CFLAGS  += $(CFLAGSNO) -O -DRUN_AS_SYSTEM -DROM_RUN

--- a/cpu/arm/stm32f103/Makefile.stm32f103
+++ b/cpu/arm/stm32f103/Makefile.stm32f103
@@ -75,7 +75,7 @@ CFLAGSNO = -I. -I$(CONTIKI)/core -I$(CONTIKI_CPU) -I$(CONTIKI_CPU)/loader \
 	   -I$(CONTIKI_CPU)/dbg-io \
            -I$(CONTIKI)/platform/$(TARGET) \
            ${addprefix -I,$(APPDIRS)} \
-           -DWITH_UIP -DWITH_ASCII -DMCK=$(MCK) \
+           -DWITH_ASCII -DMCK=$(MCK) \
            -Wall $(ARCH_FLAGS) -g -D SUBTARGET=$(SUBTARGET)
 
 CFLAGS  += $(CFLAGSNO) -O -DRUN_AS_SYSTEM -DROM_RUN

--- a/cpu/cc2430/Makefile.cc2430
+++ b/cpu/cc2430/Makefile.cc2430
@@ -35,9 +35,9 @@ endef
 ### Banking Guesswork:
 ### Examples outside examples/sensinode do not specify banking.
 ### We automatically turn it on if its unspecified and if we are building with
-### UIP_CONF_IPV6
+### CONTIKI_WITH_IPV6
 ifndef HAVE_BANKING
-  ifeq ($(UIP_CONF_IPV6),1)
+  ifeq ($(CONTIKI_WITH_IPV6),1)
     HAVE_BANKING=1
   else
     HAVE_BANKING=0

--- a/cpu/cc253x/Makefile.cc253x
+++ b/cpu/cc253x/Makefile.cc253x
@@ -51,9 +51,9 @@ endif
 ### Banking Guesswork:
 ### Generic examples do not specify banking.
 ### We automatically turn it on if its unspecified and if we are building with
-### UIP_CONF_IPV6
+### CONTIKI_WITH_IPV6
 ifndef HAVE_BANKING
-  ifeq ($(UIP_CONF_IPV6),1)
+  ifeq ($(CONTIKI_WITH_IPV6),1)
     HAVE_BANKING=1
   else
     HAVE_BANKING=0

--- a/cpu/mc1322x/slip-uart1.c
+++ b/cpu/mc1322x/slip-uart1.c
@@ -57,7 +57,7 @@ slip_arch_writeb(unsigned char c)
  *
  */
 /*---------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 int
 putchar(int c)
 {
@@ -83,7 +83,7 @@ putchar(int c)
 
   return c;
 }
-#endif
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 /**
  * Initalize the RS232 port and the SLIP driver.

--- a/cpu/msp430/f2xxx/uart0.c
+++ b/cpu/msp430/f2xxx/uart0.c
@@ -100,8 +100,8 @@ uart0_writeb(unsigned char c)
 #endif /* TX_WITH_INTERRUPT */
 }
 /*---------------------------------------------------------------------------*/
-#if ! WITH_UIP /* If WITH_UIP is defined, putchar() is defined by the SLIP driver */
-#endif /* ! WITH_UIP */
+#if ! UIP_CONF_IPV4 /* If UIP_CONF_IPV4 is defined, putchar() is defined by the SLIP driver */
+#endif /* ! UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 /**
  * Initalize the RS232 port.

--- a/cpu/msp430/f2xxx/uart1.c
+++ b/cpu/msp430/f2xxx/uart1.c
@@ -97,8 +97,8 @@ uart1_writeb(unsigned char c)
 #endif /* TX_WITH_INTERRUPT */
 }
 /*---------------------------------------------------------------------------*/
-#if ! WITH_UIP /* If WITH_UIP is defined, putchar() is defined by the SLIP driver */
-#endif /* ! WITH_UIP */
+#if ! UIP_CONF_IPV4 /* If UIP_CONF_IPV4 is defined, putchar() is defined by the SLIP driver */
+#endif /* ! UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 /**
  * Initalize the RS232 port.

--- a/cpu/msp430/slip_uart0.c
+++ b/cpu/msp430/slip_uart0.c
@@ -49,7 +49,7 @@ slip_arch_writeb(unsigned char c)
  *
  */
 /*---------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 int
 putchar(int c)
 {
@@ -75,7 +75,7 @@ putchar(int c)
 
   return c;
 }
-#endif
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 /**
  * Initalize the RS232 port and the SLIP driver.

--- a/cpu/msp430/slip_uart1.c
+++ b/cpu/msp430/slip_uart1.c
@@ -49,7 +49,7 @@ slip_arch_writeb(unsigned char c)
  *
  */
 /*---------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 int
 putchar(int c)
 {
@@ -75,7 +75,7 @@ putchar(int c)
 
   return c;
 }
-#endif
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 /**
  * Initalize the RS232 port and the SLIP driver.

--- a/cpu/stm32w108/dev/uart1.c
+++ b/cpu/stm32w108/dev/uart1.c
@@ -120,9 +120,9 @@ uart1_writeb(unsigned char c)
 #endif /* TX_WITH_INTERRUPT */
 }
 /*---------------------------------------------------------------------------*/
-#if ! WITH_UIP
-/* If WITH_UIP is defined, putchar() is defined by the SLIP driver */
-#endif /* ! WITH_UIP */
+#if ! UIP_CONF_IPV4
+/* If UIP_CONF_IPV4 is defined, putchar() is defined by the SLIP driver */
+#endif /* ! UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 /*
  * Initalize the RS232 port.

--- a/examples/antelope/netdb/Makefile
+++ b/examples/antelope/netdb/Makefile
@@ -5,4 +5,5 @@ SMALL = 1
 
 all: netdb-client netdb-server
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/antelope/shell/Makefile
+++ b/examples/antelope/shell/Makefile
@@ -7,4 +7,5 @@ SMALL = 1
 
 all: shell-db
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/cc2530dk/Makefile
+++ b/examples/cc2530dk/Makefile
@@ -3,4 +3,5 @@ CONTIKI_PROJECT = hello-world blink-hello timer-test sensors-demo
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/cc2530dk/border-router/Makefile
+++ b/examples/cc2530dk/border-router/Makefile
@@ -2,8 +2,6 @@ DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
 
 # We need uIPv6, therefore we also need banking
 HAVE_BANKING=1
-UIP_CONF_IPV6=1
-UIP_CONF_RPL=1
 
 PROJECT_SOURCEFILES += slip-bridge.c
 
@@ -12,5 +10,5 @@ CONTIKI_PROJECT = border-router
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/cc2530dk/cc2531-usb-demo/Makefile
+++ b/examples/cc2530dk/cc2531-usb-demo/Makefile
@@ -5,4 +5,5 @@ DEFINES+=MODELS_CONF_CC2531_USB_STICK=1
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/cc2530dk/sniffer/Makefile
+++ b/examples/cc2530dk/sniffer/Makefile
@@ -7,4 +7,5 @@ all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/cc2530dk/udp-ipv6/Makefile
+++ b/examples/cc2530dk/udp-ipv6/Makefile
@@ -1,8 +1,6 @@
 DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
 
 HAVE_BANKING=1
-UIP_CONF_IPV6=1
-UIP_CONF_RPL=1
 
 PROJECT_SOURCEFILES += ping6.c
 
@@ -11,5 +9,5 @@ CONTIKI_PROJECT = client server
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/cc2538dk/Makefile
+++ b/examples/cc2538dk/Makefile
@@ -4,4 +4,5 @@ CONTIKI_PROJECT = cc2538-demo timer-test
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/cc2538dk/sniffer/Makefile
+++ b/examples/cc2538dk/sniffer/Makefile
@@ -6,5 +6,5 @@ CONTIKI_PROJECT = sniffer
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/cc2538dk/udp-ipv6-echo-server/Makefile
+++ b/examples/cc2538dk/udp-ipv6-echo-server/Makefile
@@ -1,10 +1,7 @@
-UIP_CONF_IPV6=1
-UIP_CONF_RPL=1
-
 CONTIKI_PROJECT = udp-echo-server
 
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/collect/Makefile
+++ b/examples/collect/Makefile
@@ -4,4 +4,5 @@ all: $(CONTIKI_PROJECT)
 APPS = serial-shell powertrace collect-view
 CONTIKI = ../..
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/eeprom-test/Makefile
+++ b/examples/eeprom-test/Makefile
@@ -3,4 +3,5 @@ all: $(CONTIKI_PROJECT)
 TARGET=mbxxx
 
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/email/Makefile
+++ b/examples/email/Makefile
@@ -4,4 +4,5 @@ all: $(CONTIKI_PROJECT)
 APPS = email
 
 CONTIKI = ../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/er-rest-example/Makefile
+++ b/examples/er-rest-example/Makefile
@@ -3,12 +3,6 @@ all: er-example-server er-example-client
 
 CONTIKI=../..
 
-# Contiki IPv6 configuration
-WITH_UIP6=1
-UIP_CONF_IPV6=1
-CFLAGS += -DUIP_CONF_IPV6=1
-CFLAGS += -DUIP_CONF_IPV6_RPL=1
-
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 
 # automatically build RESTful resources
@@ -37,6 +31,7 @@ APPS += rest-engine
 #CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
 #CUSTOM_RULE_S_TO_OBJECTDIR_O = 1
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 # minimal-net target is currently broken in Contiki
@@ -46,7 +41,7 @@ ${info INFO: er-example compiling with large buffers}
 CFLAGS += -DUIP_CONF_BUFFER_SIZE=1300
 CFLAGS += -DREST_MAX_CHUNK_SIZE=1024
 CFLAGS += -DCOAP_MAX_HEADER_SIZE=176
-CFLAGS += -DUIP_CONF_IPV6_RPL=0
+UIP_CONF_RPL=0
 endif
 
 # optional rules to get assembly

--- a/examples/example-shell/Makefile
+++ b/examples/example-shell/Makefile
@@ -3,5 +3,6 @@ all: $(CONTIKI_PROJECT)
 
 APPS = serial-shell
 CONTIKI = ../..
-
+CONTIKI_WITH_RIME = 1
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/extended-rf-api/Makefile
+++ b/examples/extended-rf-api/Makefile
@@ -5,4 +5,5 @@ CONTIKI_PROJECT = extended-rf-api
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/ftp/Makefile
+++ b/examples/ftp/Makefile
@@ -4,4 +4,5 @@ all: $(CONTIKI_PROJECT)
 APPS = ftp
 
 CONTIKI = ../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -1,7 +1,5 @@
 CONTIKI_PROJECT = hello-world
 all: $(CONTIKI_PROJECT)
 
-#UIP_CONF_IPV6=1
-
 CONTIKI = ../..
 include $(CONTIKI)/Makefile.include

--- a/examples/ipv6/json-ws/Makefile
+++ b/examples/ipv6/json-ws/Makefile
@@ -1,6 +1,5 @@
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
 SMALL=1
 
 PROJECT_SOURCEFILES += json-ws.c
@@ -26,4 +25,5 @@ ifneq ($(TARGET),)
 all: websense-$(TARGET)
 endif
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/ipv6/multicast/Makefile
+++ b/examples/ipv6/multicast/Makefile
@@ -1,5 +1,4 @@
 DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
-UIP_CONF_IPV6=1
 
 CONTIKI_PROJECT = root intermediate sink
 all: $(CONTIKI_PROJECT)
@@ -8,4 +7,5 @@ CONTIKI = ../../..
 
 MODULES += core/net/ipv6/multicast
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/ipv6/native-border-router/Makefile
+++ b/examples/ipv6/native-border-router/Makefile
@@ -4,9 +4,6 @@ APPS = slip-cmd
 
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL -DUIP_CONF_IPV6 -DWITH_UIP6
-
 #linker optimizations
 SMALL=1
 
@@ -23,6 +20,7 @@ APPS += $(WITH_WEBSERVER)
 CFLAGS += -DWEBSERVER=2
 endif
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 connect-router:	border-router.native

--- a/examples/ipv6/rpl-border-router/Makefile
+++ b/examples/ipv6/rpl-border-router/Makefile
@@ -3,9 +3,6 @@ all: $(CONTIKI_PROJECT)
 
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
 #linker optimizations
 SMALL=1
 
@@ -37,6 +34,7 @@ ifeq ($(PREFIX),)
  PREFIX = aaaa::1/64
 endif
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 $(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c

--- a/examples/ipv6/rpl-collect/Makefile
+++ b/examples/ipv6/rpl-collect/Makefile
@@ -3,14 +3,11 @@ APPS = powertrace collect-view
 CONTIKI_PROJECT = udp-sender udp-sink
 PROJECT_SOURCEFILES += collect-common.c
 
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
 ifdef PERIOD
 CFLAGS=-DPERIOD=$(PERIOD)
 endif
 
 all: $(CONTIKI_PROJECT)
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
-

--- a/examples/ipv6/rpl-udp/Makefile
+++ b/examples/ipv6/rpl-udp/Makefile
@@ -2,10 +2,6 @@ all: udp-client udp-server
 APPS=servreg-hack
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
-
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
 ifdef WITH_COMPOWER
 APPS+=powertrace
 CFLAGS+= -DCONTIKIMAC_CONF_COMPOWER=1 -DWITH_COMPOWER=1 -DQUEUEBUF_CONF_NUM=4
@@ -18,4 +14,5 @@ ifdef PERIOD
 CFLAGS+=-DPERIOD=$(PERIOD)
 endif
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/ipv6/simple-udp-rpl/Makefile
+++ b/examples/ipv6/simple-udp-rpl/Makefile
@@ -2,7 +2,5 @@ all: broadcast-example unicast-sender unicast-receiver
 APPS=servreg-hack
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/ipv6/sky-websense/Makefile
+++ b/examples/ipv6/sky-websense/Makefile
@@ -2,9 +2,6 @@ all: sky-websense
 
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
 APPS += webbrowser
 
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
@@ -12,6 +9,7 @@ CONTIKI_SOURCEFILES += wget.c
 PROJECTDIRS += ../rpl-border-router
 PROJECT_SOURCEFILES += httpd-simple.c
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 $(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c

--- a/examples/ipv6/slip-radio/Makefile
+++ b/examples/ipv6/slip-radio/Makefile
@@ -8,9 +8,6 @@ endif
 
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
-UIP_CONF_RPL=0
-
 #linker optimizations
 SMALL=1
 
@@ -26,4 +23,6 @@ ifeq ($(TARGET),econotag)
   PROJECT_SOURCEFILES += slip-radio-mc1322x.c
 endif
 
+CONTIKI_WITH_RPL = 0
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/irc/Makefile
+++ b/examples/irc/Makefile
@@ -4,4 +4,5 @@ all: $(CONTIKI_PROJECT)
 APPS = irc
 
 CONTIKI = ../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/llsec/ccm-star-tests/encryption/Makefile
+++ b/examples/llsec/ccm-star-tests/encryption/Makefile
@@ -4,11 +4,8 @@ all: $(CONTIKI_PROJECT)
 CONTIKI = ../../../..
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 
-WITH_UIP6=1
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
 #linker optimizations
 SMALL=1
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/llsec/ccm-star-tests/verification/Makefile
+++ b/examples/llsec/ccm-star-tests/verification/Makefile
@@ -4,11 +4,8 @@ all: $(CONTIKI_PROJECT)
 CONTIKI = ../../../..
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 
-WITH_UIP6=1
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
 #linker optimizations
 SMALL=1
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/mbxxx/acc-sensor/Makefile
+++ b/examples/mbxxx/acc-sensor/Makefile
@@ -3,4 +3,5 @@ CONTIKI_PROJECT = acc-example
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/mbxxx/button/Makefile
+++ b/examples/mbxxx/button/Makefile
@@ -3,4 +3,5 @@ CONTIKI_PROJECT = test-button
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/mbxxx/coffee-test/Makefile
+++ b/examples/mbxxx/coffee-test/Makefile
@@ -4,4 +4,5 @@ all: $(CONTIKI_PROJECT)
 COFFEE=1
 
 CONTIKI = ../../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/mbxxx/mbxxx-shell/Makefile
+++ b/examples/mbxxx/mbxxx-shell/Makefile
@@ -9,4 +9,5 @@ PROJECT_SOURCEFILES = shell-sensors.c
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/mbxxx/mbxxx-websense/Makefile
+++ b/examples/mbxxx/mbxxx-websense/Makefile
@@ -2,8 +2,6 @@ all: mbxxx-websense
 
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
-
 APPS += webserver webbrowser
 
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
@@ -11,6 +9,7 @@ CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 PROJECTDIRS += ../../ipv6/rpl-border-router
 PROJECT_SOURCEFILES += httpd-simple.c
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 $(CONTIKI)/tools/tunslip6:     $(CONTIKI)/tools/tunslip6.c

--- a/examples/mbxxx/shell-exec/Makefile
+++ b/examples/mbxxx/shell-exec/Makefile
@@ -11,6 +11,7 @@ APPS = serial-shell
 PROJECT_SOURCEFILES = shell-exec.c
 CONTIKI = ../../..
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include
 
 %.shell-upload: %.ce

--- a/examples/mbxxx/telnet-server/Makefile
+++ b/examples/mbxxx/telnet-server/Makefile
@@ -1,6 +1,4 @@
 CONTIKI_PROJECT = telnet-server
-
-UIP_CONF_IPV6=1
 			
 APPS = telnetd
 
@@ -11,4 +9,5 @@ PROJECT_SOURCEFILES = shell-sensors.c
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/mbxxx/temperature/Makefile
+++ b/examples/mbxxx/temperature/Makefile
@@ -3,4 +3,5 @@ CONTIKI_PROJECT = temp-sensor
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/mbxxx/udp-ipv6-sleep/Makefile
+++ b/examples/mbxxx/udp-ipv6-sleep/Makefile
@@ -1,8 +1,7 @@
 all: udp-server udp-client
 
-UIP_CONF_IPV6=1
-
 DEFINES=UIP_CONF_ND6_REACHABLE_TIME=0xffffffff
 
 CONTIKI = ../../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/mbxxx/webserver-ajax/Makefile
+++ b/examples/mbxxx/webserver-ajax/Makefile
@@ -2,16 +2,13 @@ CONTIKI_PROJECT = mbxxx-webserver
 all: $(CONTIKI_PROJECT)
 
 DEFINES=PROJECT_CONF_H=\"webserver-ajax-conf.h\"
-UIP_CONF_IPV6=1
 
 #APPS = webserver
 
 PROJECTDIRS = . $(CONTIKI)/apps/webserver
 PROJECT_SOURCEFILES = ajax-cgi.c httpd-fs.c http-strings.c \
 				httpd.c webserver-dsc.c webserver-nogui.c
-				
-
-
 
 CONTIKI = ../../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/multi-threading/Makefile
+++ b/examples/multi-threading/Makefile
@@ -2,4 +2,5 @@ CONTIKI_PROJECT = multi-threading
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/netperf/Makefile
+++ b/examples/netperf/Makefile
@@ -3,4 +3,5 @@ all: $(CONTIKI_PROJECT)
 APPS=serial-shell
 
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/ping-ipv6/Makefile
+++ b/examples/ping-ipv6/Makefile
@@ -1,7 +1,6 @@
 all: example-ping6
 APPS=ping6
 
-UIP_CONF_IPV6=1
-
 CONTIKI = ../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/powertrace/Makefile
+++ b/examples/powertrace/Makefile
@@ -3,4 +3,5 @@ APPS+=powertrace
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/ravenusbstick/Makefile.ravenusbstick
+++ b/examples/ravenusbstick/Makefile.ravenusbstick
@@ -1,12 +1,10 @@
 all: ravenusbstick
 
 #Define CONTIKI_NO_NET=1 for a passthrough ipv6/6lowpan interface using fakeuip.c
-#Define UIP_CONF_IPV6=1 to include the uip6 stack (for rpl, internal webserver)
+#Define CONTIKI_WITH_IPV6 = 1 to include the uip6 stack (for rpl, internal webserver)
 #Do make clean when switching to remove the duplicate library modules
 CONTIKI_NO_NET=1
-#UIP_CONF_IPV6=1
-
-CFLAGS=-DUIP_CONF_IPV6=0 -DUIP_CONF_IPV6_RPL=0
+CONTIKI_WITH_IPV6=0
 
 CONTIKI = ../..
 

--- a/examples/rest-example/Makefile
+++ b/examples/rest-example/Makefile
@@ -6,8 +6,6 @@ endif
 
 CONTIKI=../..
 
-UIP_CONF_IPV6=1
-
 WITH_COAP = 1
 
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
@@ -20,6 +18,7 @@ CFLAGS += -DWITH_HTTP
 APPS += rest-http
 endif
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 $(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c

--- a/examples/rime/Makefile
+++ b/examples/rime/Makefile
@@ -4,4 +4,5 @@ all: example-abc example-mesh example-collect example-trickle example-polite \
      example-rudolph0 example-rudolph1 example-rudolph2 example-rucb \
      example-runicast example-unicast example-neighbors
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/seedeye/powerswitch/Makefile
+++ b/examples/seedeye/powerswitch/Makefile
@@ -7,12 +7,7 @@ all: remotepowerswitch
 CONTIKI=../../../
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 
-# for some platforms
-UIP_CONF_IPV6=1
-
 WITH_COAP=13
-
-UIP_CONF_RPL=1
 
 # REST framework, requires WITH_COAP
 ifeq ($(WITH_COAP), 13)
@@ -49,4 +44,5 @@ endif
 
 APPS   += erbium
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/Makefile
+++ b/examples/sensinode/Makefile
@@ -13,4 +13,5 @@ CONTIKI_PROJECT += timer-test blink-hello broadcast-rime
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/border-router/Makefile
+++ b/examples/sensinode/border-router/Makefile
@@ -7,8 +7,6 @@ DEFINES+=MODEL_N601,PROJECT_CONF_H
 
 # We need uIPv6, therefore we also need banking
 HAVE_BANKING=1
-UIP_CONF_IPV6=1
-UIP_CONF_RPL=1
 
 PROJECT_SOURCEFILES += slip-bridge.c
 
@@ -17,4 +15,5 @@ all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/cc2431-location-engine/Makefile
+++ b/examples/sensinode/cc2431-location-engine/Makefile
@@ -14,4 +14,5 @@ all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/disco/Makefile
+++ b/examples/sensinode/disco/Makefile
@@ -6,8 +6,6 @@ endif
 DEFINES+=MODEL_N740
 
 HAVE_BANKING=1
-UIP_CONF_IPV6=1
-UIP_CONF_RPL=1
 OFFSET_FIRMWARE=1
 
 CONTIKI_PROJECT = disco-example
@@ -16,4 +14,5 @@ all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/energy-scan/Makefile
+++ b/examples/sensinode/energy-scan/Makefile
@@ -13,4 +13,5 @@ all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/event-post/Makefile
+++ b/examples/sensinode/event-post/Makefile
@@ -13,5 +13,5 @@ CONTIKI_PROJECT = event-post
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/sensors-ipv6/Makefile
+++ b/examples/sensinode/sensors-ipv6/Makefile
@@ -7,7 +7,6 @@ DEFINES+=MODEL_N740,PROJECT_CONF_H
 
 # This example won't fit in flash without banking so we turn it on
 HAVE_BANKING=1
-UIP_CONF_IPV6=1
 
 CONTIKI_SOURCEFILES += sensors-driver.c
 
@@ -15,5 +14,5 @@ CONTIKI_PROJECT = sensors-ipv6
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/sensors/Makefile
+++ b/examples/sensinode/sensors/Makefile
@@ -13,5 +13,5 @@ CONTIKI_PROJECT = sensors-example
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/serial-flash/Makefile
+++ b/examples/sensinode/serial-flash/Makefile
@@ -10,4 +10,5 @@ CONTIKI_PROJECT = flash
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/sniffer/Makefile
+++ b/examples/sensinode/sniffer/Makefile
@@ -12,5 +12,5 @@ CONTIKI_PROJECT = sniffer
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/udp-ipv6/Makefile
+++ b/examples/sensinode/udp-ipv6/Makefile
@@ -7,8 +7,6 @@ DEFINES+=MODEL_N740,PROJECT_CONF_H
 
 # This example won't fit in flash without banking so we turn it on
 HAVE_BANKING=1
-UIP_CONF_IPV6=1
-UIP_CONF_RPL=1
 
 CONTIKI_SOURCEFILES += ping6.c
 
@@ -16,5 +14,5 @@ CONTIKI_PROJECT = client server
 all: $(CONTIKI_PROJECT) 
 
 CONTIKI = ../../..
-
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/servreg-hack/Makefile
+++ b/examples/servreg-hack/Makefile
@@ -1,10 +1,9 @@
 CONTIKI_PROJECT = example-servreg-client
 all: $(CONTIKI_PROJECT)
 
-UIP_CONF_IPV6=1
-
 APPS=servreg-hack
 CONTIKI = ../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 -include /home/user/nes/testbed-scripts/Makefile.include
 

--- a/examples/settings-example/Makefile
+++ b/examples/settings-example/Makefile
@@ -2,4 +2,5 @@ CONTIKI_PROJECT = settings-example
 all: $(CONTIKI_PROJECT)
 CFLAGS += -DCONTIKI_CONF_SETTINGS_MANAGER=1
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/sky-ip/Makefile
+++ b/examples/sky-ip/Makefile
@@ -2,7 +2,7 @@ CONTIKI_PROJECT = sky-webserver
 all: sky-webserver sky-telnet-server telnet 
 PLATFORM_BUILD=1 # This is needed to avoid the shell to include the httpd-cfs version of the webserver
 APPS = webserver telnetd
-CFLAGS = -DWITH_UIP=1 -I.
+CFLAGS = -I.
 SMALL=1
 DEFINES=NETSTACK_CONF_RDC=cxmac_driver,NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE=8
 
@@ -19,6 +19,8 @@ DEFINES=NETSTACK_CONF_RDC=cxmac_driver,NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE=8
 # endif
 
 CONTIKI = ../..
+CONTIKI_WITH_IPV4 = 1
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include
 
 sky-webserver.$(TARGET): $(OBJECTDIR)/ajax-cgi.o

--- a/examples/sky-shell-exec/Makefile
+++ b/examples/sky-shell-exec/Makefile
@@ -7,6 +7,7 @@ DEFINES=ELFLOADER_DATAMEMORY_SIZE=0x100,ELFLOADER_TEXTMEMORY_SIZE=0x100
 
 APPS = serial-shell
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include
 
 %.shell-upload: %.ce

--- a/examples/sky-shell-webserver/Makefile
+++ b/examples/sky-shell-webserver/Makefile
@@ -2,11 +2,13 @@ CONTIKI_PROJECT = sky-shell-webserver
 all: $(CONTIKI_PROJECT)
 PROJECT_SOURCEFILES = webserver-nogui.c
 HTTPD_CFS=1
-CFLAGS = -DWITH_UIP=1 -DRESOLV_CONF_SUPPORTS_MDNS=0
+CFLAGS = -DRESOLV_CONF_SUPPORTS_MDNS=0
 DEFINES=NETSTACK_MAC=nullmac_driver,NETSTACK_RDC=nullrdc_driver 
 SMALL=1
 
 CONTIKI = ../..
 APPS = webserver serial-shell
+CONTIKI_WITH_IPV4 = 1
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include
- 
+

--- a/examples/sky-shell-webserver/sky-shell-webserver.c
+++ b/examples/sky-shell-webserver/sky-shell-webserver.c
@@ -51,7 +51,7 @@ PROCESS_THREAD(sky_shell_process, ev, data)
 {
   PROCESS_BEGIN();
 
-  /* WITH_UIP=1 assumes incoming SLIP serial data.
+  /* UIP_CONF_IPV4=1 assumes incoming SLIP serial data.
    * We override this assumption by restoring default serial input handler. */
   uart1_set_input(serial_line_input_byte);
   serial_line_init();

--- a/examples/sky-shell/Makefile
+++ b/examples/sky-shell/Makefile
@@ -4,6 +4,7 @@ all: $(CONTIKI_PROJECT)
 APPS = serial-shell powertrace collect-view
 CONTIKI = ../..
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include
 -include /home/user/nes/testbed-scripts/Makefile.include
 

--- a/examples/sky/Makefile
+++ b/examples/sky/Makefile
@@ -17,4 +17,6 @@ all: blink sky-collect #rt-leds test-button test-cfs tcprudolph0
 viewrssi: ViewRSSI.class
 	make login | java ViewRSSI
 
+CONTIKI_WITH_IPV4 = 1
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/tcp-socket/Makefile
+++ b/examples/tcp-socket/Makefile
@@ -1,5 +1,5 @@
 all: tcp-server
 
 CONTIKI=../..
-
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/telnet-server/Makefile
+++ b/examples/telnet-server/Makefile
@@ -3,7 +3,6 @@ all: $(CONTIKI_PROJECT)
 
 APPS = telnetd program-handler
 
-WITH_UIP=1
-
 CONTIKI = ../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/trickle-library/Makefile
+++ b/examples/trickle-library/Makefile
@@ -1,9 +1,8 @@
-UIP_CONF_IPV6=1
-
 CONTIKI_PROJECT = trickle-library
 
 all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../..
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/udp-ipv6/Makefile
+++ b/examples/udp-ipv6/Makefile
@@ -1,6 +1,5 @@
 all: udp-server udp-client
 
-UIP_CONF_IPV6=1
-
 CONTIKI = ../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/udp-stream/Makefile
+++ b/examples/udp-stream/Makefile
@@ -6,8 +6,8 @@ ifndef TARGET
 TARGET = sky
 endif
 
-UIP_CONF_IPV6 = 1
 CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 SMALL = 1
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/webbrowser/Makefile
+++ b/examples/webbrowser/Makefile
@@ -4,4 +4,5 @@ all: $(CONTIKI_PROJECT)
 APPS = webbrowser
 
 CONTIKI = ../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/webserver-ipv6-raven/Makefile.webserver
+++ b/examples/webserver-ipv6-raven/Makefile.webserver
@@ -3,9 +3,7 @@ all: webserver6
 
 APPS=raven-webserver raven-lcd-interface
 TARGET=avr-raven
-UIP_CONF_IPV6=1
 
-#UIP_CONF_RPL=0        //RPL is now the default.
 #RF230BB=1             //Use radio driver that communicates with the core MAC layer. Now the default.
 #COFFEE_FILES=1        //Static coffee file system in EEPROM
 #COFFEE_FILES=2        //Dynamic coffee file system in EEPROM
@@ -14,5 +12,5 @@ UIP_CONF_IPV6=1
 #COFFEE_ADDRESS=0xnnnn //Override default coffee file system starting address
 CONTIKI = ../..
 
-
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/webserver-ipv6/Makefile
+++ b/examples/webserver-ipv6/Makefile
@@ -34,9 +34,6 @@ all : $(CONTIKI_PROJECT)
 	@if (test -n "$(ELF_SIZE)");then $(ELF_SIZE) $(CONTIKI_PROJECT).$(TARGET);fi	
 endif
 
-UIP_CONF_IPV6=1
-DEFINES=WITH_UIP6
-
 # Make no RPL the default for minimal-net builds
 ifeq ($(TARGET),minimal-net)
 ifndef UIP_CONF_RPL
@@ -45,4 +42,5 @@ endif
 endif
 
 CONTIKI = ../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/webserver/Makefile
+++ b/examples/webserver/Makefile
@@ -16,6 +16,7 @@ ifeq ($(HTTPD-CFS),1)
 endif
 
 CONTIKI = ../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include
 
 # Intentionally httpd.c and httpd-cfs.c implement the same interface. When

--- a/examples/wget/Makefile
+++ b/examples/wget/Makefile
@@ -4,4 +4,5 @@ all: $(CONTIKI_PROJECT)
 APPS = webbrowser
 
 CONTIKI = ../..
+CONTIKI_WITH_IPV4 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/z1/Makefile
+++ b/examples/z1/Makefile
@@ -15,4 +15,5 @@ endif
 
 all: $(CONTIKI_PROJECT)
 CONTIKI = ../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/z1/ipv6/z1-websense/Makefile
+++ b/examples/z1/ipv6/z1-websense/Makefile
@@ -2,8 +2,6 @@ all: z1-websense
 
 CONTIKI=../../../..
 
-UIP_CONF_IPV6=1
-
 SMALL=1
 
 APPS += webserver webbrowser
@@ -13,6 +11,7 @@ CONTIKI_SOURCEFILES += wget.c
 PROJECTDIRS += ../../../ipv6/rpl-border-router
 PROJECT_SOURCEFILES += httpd-simple.c
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 $(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c

--- a/examples/z1/rssi_scanner/Makefile
+++ b/examples/z1/rssi_scanner/Makefile
@@ -29,5 +29,6 @@ viewrssi: ViewRSSI.class
 
 # ContikiProjects: including the makefile
 #include ../../../Makefile.projects
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include
 

--- a/examples/z1/tutorials/Makefile
+++ b/examples/z1/tutorials/Makefile
@@ -9,6 +9,7 @@ CONTIKI_SOURCEFILES += cc2420-arch.c sensors.c sht11.c
 PROJECT_SOURCEFILES = i2cmaster.c tmp102.c adxl345.c battery-sensor.c sky-sensors.c #potentiometer-sensor.c
 all: example-unicast2
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include
 
 

--- a/platform/avr-atmega128rfa1/contiki-main.c
+++ b/platform/avr-atmega128rfa1/contiki-main.c
@@ -308,7 +308,9 @@ uint8_t i;
 
 #endif /* ANNOUNCE_BOOT */
 
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
+#endif
 
 #ifdef RAVEN_LCD_INTERFACE
   process_start(&raven_lcd_process, NULL);

--- a/platform/avr-raven/Makefile.avr-raven
+++ b/platform/avr-raven/Makefile.avr-raven
@@ -35,5 +35,5 @@ AVRDUDE_MCU=m1284p
 include $(CONTIKIAVR)/Makefile.avr
 include $(CONTIKIAVR)/radio/Makefile.radio
 
-MODULES += core/net/ipv6 core/net/ipv4 core/net/ip core/net/mac core/net core/net/rime core/net/mac/sicslowmac \
+MODULES += core/net/mac core/net core/net/mac/sicslowmac \
            core/net/llsec

--- a/platform/avr-raven/contiki-raven-main.c
+++ b/platform/avr-raven/contiki-raven-main.c
@@ -316,13 +316,17 @@ uint8_t i;
 // rime_init(rime_udp_init(NULL));
 // uip_router_register(&rimeroute);
 
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
+#endif
 
 #else /* !RF230BB */
 /* Original RF230 combined mac/radio driver */
 /* mac process must be started before tcpip process! */
   process_start(&mac_process, NULL);
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
+#endif
 #endif /* RF230BB */
 
 #ifdef RAVEN_LCD_INTERFACE

--- a/platform/avr-ravenusb/Makefile.avr-ravenusb
+++ b/platform/avr-ravenusb/Makefile.avr-ravenusb
@@ -67,8 +67,7 @@ include $(CONTIKIAVR)/Makefile.avr
 include $(CONTIKIAVR)/radio/Makefile.radio
 
 ifndef CONTIKI_NO_NET
-MODULES+=core/net/ip core/net/ipv4 core/net core/net/ipv6 \
-         core/net/rime core/net/mac core/net/mac/sicslowmac \
+MODULES+=core/net/mac core/net/mac/sicslowmac \
          core/net/llsec
 else
 vpath %.c $(CONTIKI)/core/net/ipv6

--- a/platform/avr-ravenusb/contiki-raven-main.c
+++ b/platform/avr-ravenusb/contiki-raven-main.c
@@ -552,7 +552,9 @@ uint16_t p=(uint16_t)&__bss_end;
 #else  /* RF230BB */
 /* The order of starting these is important! */
   process_start(&mac_process, NULL);
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
+#endif
 #endif /* RF230BB */
 
   /* Start ethernet network and storage process */

--- a/platform/avr-rcb/contiki-rcb-main.c
+++ b/platform/avr-rcb/contiki-rcb-main.c
@@ -74,9 +74,17 @@ FUSES =
 PROCESS(rcb_leds, "RCB leds process");
 
 #if RF230BB
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
 PROCINIT(&etimer_process, &tcpip_process, &rcb_leds);
 #else
+PROCINIT(&etimer_process, &rcb_leds);
+#endif
+#else
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
 PROCINIT(&etimer_process, &mac_process, &tcpip_process, &rcb_leds);
+#else
+PROCINIT(&etimer_process, &mac_process, &rcb_leds);
+#endif
 #endif
 
 /* Put default MAC address in EEPROM */

--- a/platform/avr-zigbit/contiki-avr-zigbit-main.c
+++ b/platform/avr-zigbit/contiki-avr-zigbit-main.c
@@ -82,9 +82,17 @@ FUSES =
 	};
 	
 #if RF230BB
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
 //PROCINIT(&etimer_process, &tcpip_process );
 #else
+//PROCINIT(&etimer_process );
+#endif
+#else
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
 PROCINIT(&etimer_process, &mac_process, &tcpip_process );
+#else
+PROCINIT(&etimer_process, &mac_process );
+#endif
 #endif
 /* Put default MAC address in EEPROM */
 uint8_t mac_address[8] EEMEM = {0x02, 0x11, 0x22, 0xff, 0xfe, 0x33, 0x44, 0x55};
@@ -162,13 +170,15 @@ init_lowlevel(void)
   rime_init(rime_udp_init(NULL));
   uip_router_register(&rimeroute);
 #endif
-
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
-
+#endif
 #else
 /* mac process must be started before tcpip process! */
   process_start(&mac_process, NULL);
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
+#endif
 #endif /*RF230BB*/
 
 }

--- a/platform/cc2530dk/Makefile.cc2530dk
+++ b/platform/cc2530dk/Makefile.cc2530dk
@@ -19,7 +19,7 @@ CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
 CLEAN += *.cc2530dk
 
-ifeq ($(UIP_CONF_IPV6),1)
+ifeq ($(CONTIKI_WITH_IPV6),1)
   CONTIKI_TARGET_SOURCEFILES += viztool.c
 endif
 
@@ -47,5 +47,5 @@ CONTIKI_CPU=$(CONTIKI)/cpu/cc253x
 include $(CONTIKI_CPU)/Makefile.cc253x
 
 # Default modules
-MODULES += core/net/ip core/net/ipv6 core/net/rime core/net core/net/mac core/net/rpl \
+MODULES += core/net core/net/mac \
            core/net/llsec

--- a/platform/cc2538dk/Makefile.cc2538dk
+++ b/platform/cc2538dk/Makefile.cc2538dk
@@ -27,8 +27,8 @@ endif
 CONTIKI_CPU=$(CONTIKI)/cpu/cc2538
 include $(CONTIKI_CPU)/Makefile.cc2538
 
-MODULES += core/net core/net/ipv6 core/net/mac core/net/ip \
-           core/net/rpl core/net/rime core/net/mac/contikimac \
+MODULES += core/net core/net/mac \
+           core/net/mac/contikimac \
            core/net/llsec
 
 BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py

--- a/platform/cooja/Makefile.cooja
+++ b/platform/cooja/Makefile.cooja
@@ -74,21 +74,29 @@ CONTIKI_CPU=$(CONTIKI)/cpu/x86
 CFLAGSNO = $(EXTRA_CC_ARGS) -Wall -g -I/usr/local/include -DCLASSNAME=$(CLASSNAME)
 CFLAGS   += $(CFLAGSNO)
 
-ifeq ($(UIP_CONF_IPV6),1)
-  CFLAGS += -DWITH_UIP6=1
-endif
-ifdef WITH_UIP
-  CFLAGS += -DWITH_UIP=1
-endif
+MODULES += core/net core/net/mac core/net/rime \
+           core/net/llsec
 
 ## Copied from Makefile.include, since Cooja overrides CFLAGS et al
-ifeq ($(UIP_CONF_IPV6),1)
+HAS_STACK = 0
+ifeq ($(CONTIKI_WITH_IPV4),1)
+  HAS_STACK = 1
+  CFLAGS += -DUIP_CONF_IPV4=1
+endif
+
+ifeq ($(CONTIKI_WITH_RIME),1)
+  HAS_STACK = 1
+  CFLAGS += -DUIP_CONF_RIME=1 
+endif
+
+# Make IPv6 the default stack
+ifeq ($(HAS_STACK),0)
+CONTIKI_WITH_IPV6 = 1
+endif
+
+ifeq ($(CONTIKI_WITH_IPV6),1)
   CFLAGS += -DUIP_CONF_IPV6=1
-  ifneq ($(UIP_CONF_RPL),0)
+  ifneq ($(CONTIKI_WITH_RPL),0)
     CFLAGS += -DUIP_CONF_IPV6_RPL=1
   endif # UIP_CONF_RPL
-endif # UIP_CONF_IPV6
-
-MODULES += core/net core/net/ip core/net/ipv4 \
-           core/net/ipv6 core/net/mac core/net/rime core/net/rpl \
-           core/net/llsec
+endif

--- a/platform/cooja/contiki-conf.h
+++ b/platform/cooja/contiki-conf.h
@@ -47,11 +47,11 @@
 
 #define w_memcpy memcpy
 
-#if WITH_UIP
-#if WITH_UIP6
-#error WITH_UIP && WITH_IP6: Bad configuration
-#endif /* WITH_UIP6 */
-#endif /* WITH_UIP */
+#if UIP_CONF_IPV4
+#if UIP_CONF_IPV6
+#error UIP_CONF_IPV4 && UIP_CONF_IPV6: Bad configuration
+#endif /* UIP_CONF_IPV6 */
+#endif /* UIP_CONF_IPV4 */
 
 #ifdef NETSTACK_CONF_H
 
@@ -63,7 +63,7 @@
 #else /* NETSTACK_CONF_H */
 
 /* Default network config */
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 
 #define NULLRDC_CONF_802154_AUTOACK  1
 #define NULLRDC_CONF_SEND_802154_ACK 1
@@ -78,9 +78,9 @@
 #define NETSTACK_CONF_RADIO         cooja_radio_driver
 #define NETSTACK_CONF_FRAMER        framer_802154
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
 
 /* Network setup for IPv4 */
 #define NETSTACK_CONF_NETWORK rime_driver /* NOTE: uip_over_mesh. else: uip_driver */
@@ -89,7 +89,7 @@
 #define NETSTACK_CONF_RADIO cooja_radio_driver
 #define UIP_CONF_IP_FORWARD           1
 
-#else /* WITH_UIP */
+#else /* UIP_CONF_IPV4 */
 
 /* Network setup for Rime */
 #define NETSTACK_CONF_NETWORK rime_driver
@@ -98,15 +98,15 @@
 #define NETSTACK_CONF_RADIO cooja_radio_driver
 /*#define NETSTACK_CONF_FRAMER framer_nullmac*/
 
-#endif /* WITH_UIP */
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV4 */
+#endif /* UIP_CONF_IPV6 */
 
 #endif /* NETSTACK_CONF_H */
 
 #define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE 8
 
 /* Default network config */
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 
 
 
@@ -174,7 +174,7 @@
 #define SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS   8
 #endif /* SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS */
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 
 #define PACKETBUF_CONF_ATTRS_INLINE 1

--- a/platform/cooja/contiki-cooja-main.c
+++ b/platform/cooja/contiki-cooja-main.c
@@ -75,10 +75,10 @@
 #define Java_org_contikios_cooja_corecomm_CLASSNAME_tick COOJA__QUOTEME(COOJA_JNI_PATH,CLASSNAME,_tick)
 #define Java_org_contikios_cooja_corecomm_CLASSNAME_setReferenceAddress COOJA__QUOTEME(COOJA_JNI_PATH,CLASSNAME,_setReferenceAddress)
 
-#ifndef WITH_UIP
-#define WITH_UIP 0
+#ifndef UIP_CONF_IPV4
+#define UIP_CONF_IPV4 0
 #endif
-#if WITH_UIP
+#if UIP_CONF_IPV4
 #include "dev/rs232.h"
 #include "dev/slip.h"
 #include "net/ip/uip.h"
@@ -92,16 +92,16 @@ static struct uip_fw_netif meshif =
 
 #define UIP_OVER_MESH_CHANNEL 8
 static uint8_t is_gateway;
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
-#ifndef WITH_UIP6
-#define WITH_UIP6 0
+#ifndef UIP_CONF_IPV6
+#define UIP_CONF_IPV6 0
 #endif
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ip/uip.h"
 #include "net/ipv6/uip-ds6.h"
 #define PRINT6ADDR(addr) printf("%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x", ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], ((uint8_t *)addr)[4], ((uint8_t *)addr)[5], ((uint8_t *)addr)[6], ((uint8_t *)addr)[7], ((uint8_t *)addr)[8], ((uint8_t *)addr)[9], ((uint8_t *)addr)[10], ((uint8_t *)addr)[11], ((uint8_t *)addr)[12], ((uint8_t *)addr)[13], ((uint8_t *)addr)[14], ((uint8_t *)addr)[15])
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 /* Simulation mote interfaces */
 SIM_INTERFACE_NAME(moteid_interface);
@@ -139,7 +139,7 @@ static struct cooja_mt_thread process_run_thread;
 #define MIN(a, b)   ( (a)<(b) ? (a) : (b) )
 
 /*---------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 static void
 set_gateway(void)
 {
@@ -153,7 +153,7 @@ set_gateway(void)
     is_gateway = 1;
   }
 }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 static void
 print_processes(struct process * const processes[])
@@ -186,15 +186,15 @@ set_rime_addr(void)
   int i;
 
   memset(&addr, 0, sizeof(linkaddr_t));
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   for(i = 0; i < sizeof(uip_lladdr.addr); i += 2) {
     addr.u8[i + 1] = node_id & 0xff;
     addr.u8[i + 0] = node_id >> 8;
   }
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
   addr.u8[0] = node_id & 0xff;
   addr.u8[1] = node_id >> 8;
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
   linkaddr_set_node_addr(&addr);
   printf("Rime started with address ");
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
@@ -246,7 +246,7 @@ contiki_init()
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0 ? 1:
                          NETSTACK_RDC.channel_check_interval()));
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
   /* IPv4 CONFIGURATION */
   {
     uip_ipaddr_t hostaddr, netmask;
@@ -273,9 +273,9 @@ contiki_init()
     rs232_set_input(slip_input_byte);
     printf("IPv4 address: %d.%d.%d.%d\n", uip_ipaddr_to_quad(&hostaddr));
   }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   /* IPv6 CONFIGURATION */
   {
     int i;
@@ -317,7 +317,7 @@ contiki_init()
              ipaddr.u8[7 * 2], ipaddr.u8[7 * 2 + 1]);
     }
   }
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
   /* Initialize eeprom */
   eeprom_init();

--- a/platform/cooja/dev/ip.c
+++ b/platform/cooja/dev/ip.c
@@ -44,12 +44,12 @@ char simIP[16];
 
 #endif /* UIP_CONF_IPV6 */
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
 
 char simIPChanged;
 char simIP[4];
 
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 /*-----------------------------------------------------------------------------------*/
 static void
@@ -61,7 +61,7 @@ doInterfaceActionsBeforeTick(void)
 
 #endif /* UIP_CONF_IPV6 */
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
 
   /* check if IPv4 address should change */
 /*
@@ -73,7 +73,7 @@ doInterfaceActionsBeforeTick(void)
   }
 */
 
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 }
 /*-----------------------------------------------------------------------------------*/
 static void

--- a/platform/cooja/sys/log.c
+++ b/platform/cooja/sys/log.c
@@ -36,13 +36,13 @@
 
 #define IMPLEMENT_PRINTF 1
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
 /* uIP packets via SLIP */
 #include "uip.h"
 #define MAX_LOG_LENGTH (2*UIP_BUFSIZE)
-#else /* WITH_UIP */
+#else /* UIP_CONF_IPV4 */
 #define MAX_LOG_LENGTH 1024
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 #if MAX_LOG_LENGTH < 1024
 #undef MAX_LOG_LENGTH

--- a/platform/econotag/Makefile.econotag
+++ b/platform/econotag/Makefile.econotag
@@ -14,12 +14,8 @@ CONTIKI_PLAT_DEFS =
 
 MCU=arm7tdmi-s
 
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
-endif
-
 include $(CONTIKIMC1322X)/Makefile.mc1322x
 
-MODULES+=core/net/ip core/net/ipv4 core/net core/net/rpl \
-         core/net/ipv6 core/net/rime core/net/mac \
+MODULES+=core/net \
+         core/net/mac \
          core/net/llsec

--- a/platform/econotag/contiki-conf.h
+++ b/platform/econotag/contiki-conf.h
@@ -108,7 +108,7 @@
 
 #define LINKADDR_CONF_SIZE              8
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
 #define NETSTACK_CONF_MAC     nullmac_driver 
@@ -121,7 +121,7 @@
 #define CXMAC_CONF_ANNOUNCEMENTS         0
 #define XMAC_CONF_ANNOUNCEMENTS          0
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 /* Network setup for non-IPv6 (rime). */
 
 #define NETSTACK_CONF_NETWORK rime_driver
@@ -144,7 +144,7 @@
 
 #define COLLECT_NBR_TABLE_CONF_MAX_NEIGHBORS      32
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define QUEUEBUF_CONF_NUM          16
 
@@ -169,7 +169,7 @@
 #define PROCESS_CONF_NUMEVENTS 8
 #define PROCESS_CONF_STATS 1
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -213,10 +213,10 @@
 #endif /* SICSLOWPAN_CONF_FRAG */
 #define SICSLOWPAN_CONF_CONVENTIONAL_MAC	1
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 #define UIP_CONF_IP_FORWARD      1
 #define UIP_CONF_BUFFER_SIZE     1300
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define UIP_CONF_ICMP_DEST_UNREACH 1
 

--- a/platform/econotag/main.c
+++ b/platform/econotag/main.c
@@ -124,7 +124,7 @@ int main(void) {
 	/* configure address on maca hardware and RIME */
 	contiki_maca_set_mac_address(mc1322x_config.eui);
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 	memcpy(&uip_lladdr.addr, &linkaddr_node_addr.u8, sizeof(uip_lladdr.addr));
 	queuebuf_init();
 	NETSTACK_RDC.init();
@@ -137,7 +137,7 @@ int main(void) {
   #if DEBUG_ANNOTATE
 	print_lladdrs();
   #endif
-#endif /* endif WITH_UIP6 */
+#endif /* endif UIP_CONF_IPV6 */
 
 	process_start(&sensors_process, NULL);
 

--- a/platform/ev-aducrf101mkxz/Makefile.ev-aducrf101mkxz
+++ b/platform/ev-aducrf101mkxz/Makefile.ev-aducrf101mkxz
@@ -48,19 +48,10 @@ CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
 CONTIKI_PLAT_DEFS =
 
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
-endif
-
 include $(CONTIKI)/cpu/arm/aducrf101/Makefile.aducrf101
 
 MODULES += \
 	core/net \
-	core/net/rpl \
-	core/net/ip \
-	core/net/ipv4 \
-        core/net/ipv6 \
-	core/net/rime \
 	core/net/mac \
 	core/net/mac/sicslowmac \
 	core/net/llsec

--- a/platform/ev-aducrf101mkxz/contiki-conf.h
+++ b/platform/ev-aducrf101mkxz/contiki-conf.h
@@ -55,7 +55,7 @@
 
 #define LINKADDR_CONF_SIZE              8
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK           sicslowpan_driver
 #define NETSTACK_CONF_MAC               nullmac_driver
@@ -68,7 +68,7 @@
 #define CXMAC_CONF_ANNOUNCEMENTS                0
 #define XMAC_CONF_ANNOUNCEMENTS                 0
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
 /* Network setup for non-IPv6 (rime). */
 #define NETSTACK_CONF_NETWORK           rime_driver
@@ -91,7 +91,7 @@
 
 #define COLLECT_NBR_TABLE_CONF_MAX_NEIGHBORS    16
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define QUEUEBUF_CONF_NUM               4
 
@@ -116,7 +116,7 @@
 #define PROCESS_CONF_NUMEVENTS          8
 #define PROCESS_CONF_STATS              1
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -160,10 +160,10 @@
 #endif /* SICSLOWPAN_CONF_FRAG */
 #define SICSLOWPAN_CONF_CONVENTIONAL_MAC        1
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 #define UIP_CONF_IP_FORWARD             1
 #define UIP_CONF_BUFFER_SIZE            140
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define UIP_CONF_ICMP_DEST_UNREACH      1
 

--- a/platform/ev-aducrf101mkxz/contiki-main.c
+++ b/platform/ev-aducrf101mkxz/contiki-main.c
@@ -49,9 +49,9 @@
 #include "dev/button-sensor.h"
 #include "dev/leds.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #include "net/rime/rime.h"
 
@@ -142,7 +142,7 @@ main(int argc, char **argv)
   printf("MAC %s RDC %s NETWORK %s\n",
          NETSTACK_MAC.name, NETSTACK_RDC.name, NETSTACK_NETWORK.name);
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   memcpy(&uip_lladdr.addr, serial_id, sizeof(uip_lladdr.addr));
 
   process_start(&tcpip_process, NULL);
@@ -159,7 +159,7 @@ main(int argc, char **argv)
     /* make it hardcoded... */
     lladdr->state = ADDR_AUTOCONF;
   }
-#else
+#elif UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
 #endif
 

--- a/platform/eval-adf7xxxmb4z/Makefile.eval-adf7xxxmb4z
+++ b/platform/eval-adf7xxxmb4z/Makefile.eval-adf7xxxmb4z
@@ -51,10 +51,6 @@ CONTIKIBOARD = .
 
 CONTIKI_PLAT_DEFS = 
 
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
-endif
-
 include $(CONTIKIRL78)/Makefile.rl78
 
 PROG_UART ?= /dev/ttyUSB1
@@ -62,6 +58,6 @@ PROG_UART ?= /dev/ttyUSB1
 run: $(CONTIKI_PROJECT).$(TARGET).srec
 	~/adi-contiki/github/rl78flash/rl78flash -vv -i -m3 $(PROG_UART) -b500000 -a $<
 
-MODULES+=core/net/ip core/net/ipv4 core/net core/net/rpl \
-         core/net/ipv6 core/net/rime core/net/mac core/net/mac/sicslowmac \
+MODULES+=core/net \
+         core/net/mac core/net/mac/sicslowmac \
          core/net/llsec

--- a/platform/eval-adf7xxxmb4z/contiki-conf.h
+++ b/platform/eval-adf7xxxmb4z/contiki-conf.h
@@ -58,7 +58,7 @@
 
 #define LINKADDR_CONF_SIZE              8
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
 #define NETSTACK_CONF_MAC     nullmac_driver
@@ -71,7 +71,7 @@
 #define CXMAC_CONF_ANNOUNCEMENTS         0
 #define XMAC_CONF_ANNOUNCEMENTS          0
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 /* Network setup for non-IPv6 (rime). */
 
 #define NETSTACK_CONF_NETWORK rime_driver
@@ -94,7 +94,7 @@
 
 #define COLLECT_NBR_TABLE_CONF_MAX_NEIGHBORS      32
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define QUEUEBUF_CONF_NUM          16
 
@@ -119,7 +119,7 @@
 #define PROCESS_CONF_NUMEVENTS 8
 #define PROCESS_CONF_STATS 1
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -163,10 +163,10 @@
 #endif /* SICSLOWPAN_CONF_FRAG */
 #define SICSLOWPAN_CONF_CONVENTIONAL_MAC  1
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 #define UIP_CONF_IP_FORWARD      1
 #define UIP_CONF_BUFFER_SIZE     1300
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define UIP_CONF_ICMP_DEST_UNREACH 1
 

--- a/platform/eval-adf7xxxmb4z/contiki-main.c
+++ b/platform/eval-adf7xxxmb4z/contiki-main.c
@@ -45,9 +45,9 @@
 
 #include "dev/button-sensor.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #include "net/rime/rime.h"
 #include "uart0.h"
@@ -183,7 +183,7 @@ main(int argc, char **argv)
   netstack_init();
   printf("MAC %s RDC %s NETWORK %s" NEWLINE, NETSTACK_MAC.name, NETSTACK_RDC.name, NETSTACK_NETWORK.name);
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   memcpy(&uip_lladdr.addr, serial_id, sizeof(uip_lladdr.addr));
 
   process_start(&tcpip_process, NULL);
@@ -201,7 +201,7 @@ main(int argc, char **argv)
 
     printf("%02x%02x" NEWLINE, lladdr->ipaddr.u8[14], lladdr->ipaddr.u8[15]);
   }
-#else
+#elif UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
 #endif
 

--- a/platform/exp5438/Makefile.exp5438
+++ b/platform/exp5438/Makefile.exp5438
@@ -1,8 +1,8 @@
 # $Id: Makefile.z1,v 1.4 2010/11/07 08:40:24 enricmcalvo Exp $
 # msp430flasher -n msp430x5437 -w "Firmware.txt" -v -z [VCC]
 
-MODULES += core/net core/net/ip core/net/ipv6 core/net/ipv4 \
-           core/net/mac core/net/rpl core/net/rime core/net/mac/contikimac \
+MODULES += core/net \
+           core/net/mac core/net/mac/contikimac \
            core/net/llsec dev/cc2420
 
 ifdef IAR
@@ -42,10 +42,6 @@ help:
 CONTIKI_TARGET_DIRS = . dev apps net
 ifndef CONTIKI_TARGET_MAIN
 CONTIKI_TARGET_MAIN = contiki-exp5438-main.c
-endif
-
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
 endif
 
 CONTIKI_TARGET_SOURCEFILES += $(ARCH) $(UIPDRIVERS)

--- a/platform/exp5438/contiki-conf.h
+++ b/platform/exp5438/contiki-conf.h
@@ -35,7 +35,7 @@
 
 #define NULLRDC_CONF_802154_AUTOACK 1
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
 
@@ -52,7 +52,7 @@
 #define QUEUEBUF_CONF_NUM                8
 #endif
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
 /* Network setup for non-IPv6 (rime). */
 
@@ -85,7 +85,7 @@
 #define CC2420_CONF_SFD_TIMESTAMPS       1
 #endif /* TIMESYNCH_CONF_ENABLED */
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define PACKETBUF_CONF_ATTRS_INLINE 1
 
@@ -131,7 +131,7 @@
 #define PROCESS_CONF_STATS 1
 /*#define PROCESS_CONF_FASTPOLL    4*/
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -182,10 +182,10 @@
 #ifndef SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS
 #define SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS   5
 #endif /* SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS */
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 #define UIP_CONF_IP_FORWARD      1
 #define UIP_CONF_BUFFER_SIZE     108
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define UIP_CONF_ICMP_DEST_UNREACH 1
 

--- a/platform/exp5438/contiki-exp5438-main.c
+++ b/platform/exp5438/contiki-exp5438-main.c
@@ -53,9 +53,9 @@
 #include "lcd.h"
 #include "duty-cycle-scroller.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 
 #define DEBUG 1
@@ -122,9 +122,9 @@ main(int argc, char **argv)
   leds_on(LEDS_RED);
 
   uart1_init(BAUD2UBR(115200)); /* Must come before first printf */
-#if WITH_UIP
+#if UIP_CONF_IPV4
   slip_arch_init(BAUD2UBR(115200));
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
   leds_on(LEDS_GREEN);
   /* xmem_init(); */
@@ -203,7 +203,7 @@ main(int argc, char **argv)
     PRINTF("Node id not set.\n");
   }
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   memcpy(&uip_lladdr.addr, node_mac, sizeof(uip_lladdr.addr));
   /* Setup nullmac-like MAC for 802.15.4 */
 
@@ -248,7 +248,7 @@ main(int argc, char **argv)
            ipaddr.u8[7 * 2], ipaddr.u8[7 * 2 + 1]);
   }
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
@@ -259,9 +259,9 @@ main(int argc, char **argv)
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0? 1:
                          NETSTACK_RDC.channel_check_interval()),
          CC2420_CONF_CHANNEL);
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
-#if !WITH_UIP6
+#if !UIP_CONF_IPV6
   uart1_set_input(serial_line_input_byte);
   serial_line_init();
 #endif

--- a/platform/exp5438/uart1x.c
+++ b/platform/exp5438/uart1x.c
@@ -72,8 +72,8 @@ uart1_writeb(unsigned char c)
   UCA1TXBUF = c;
 }
 /*---------------------------------------------------------------------------*/
-#if ! WITH_UIP /* If WITH_UIP is defined, putchar() is defined by the SLIP driver */
-#endif /* ! WITH_UIP */
+#if ! UIP_CONF_IPV4 /* If UIP_CONF_IPV4 is defined, putchar() is defined by the SLIP driver */
+#endif /* ! UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 /**
  * Initalize the RS232 port.

--- a/platform/mbxxx/Makefile.mbxxx
+++ b/platform/mbxxx/Makefile.mbxxx
@@ -6,10 +6,6 @@ ifndef CONTIKI_TARGET_MAIN
 CONTIKI_TARGET_MAIN = contiki-main.c board.c
 endif
 
-ifdef UIP_CONF_IPV6
-CFLAGS += -DWITH_UIP6=1
-endif
-
 CONTIKI_TARGET_SOURCEFILES += $(ARCH) $(CONTIKI_TARGET_MAIN)
 
 MCU=STM32W108
@@ -21,6 +17,5 @@ ifeq ($(HOST_OS),Windows)
   SERIALDUMP = $(CONTIKI)/tools/stm32w/serialdump-windows
 endif
 
-MODULES+=core/net/ip core/net/ipv4 core/net core/net/ipv6 \
-         core/net/rpl core/net/rime core/net/mac core/net/mac/contikimac \
+MODULES+=core/net/mac core/net/mac/contikimac \
          core/net/llsec

--- a/platform/mbxxx/contiki-conf.h
+++ b/platform/mbxxx/contiki-conf.h
@@ -115,7 +115,7 @@
 #define RPL_CONF_MAX_DAG_PER_INSTANCE				1
 #define PROCESS_CONF_NUMEVENTS					16
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
@@ -161,12 +161,12 @@
 #define SICSLOWPAN_CONF_MAXAGE					2
 #endif /* SICSLOWPAN_CONF_MAXAGE */
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
 /* Network setup for non-IPv6 (rime). */
 #define NETSTACK_CONF_NETWORK					rime_driver
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #ifdef PROJECT_CONF_H
 #include PROJECT_CONF_H

--- a/platform/mbxxx/contiki-main.c
+++ b/platform/mbxxx/contiki-main.c
@@ -72,9 +72,9 @@
 #include "net/rime/rime.h"
 #include "net/ip/uip.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define DEBUG 1
 #if DEBUG

--- a/platform/micaz/Makefile.micaz
+++ b/platform/micaz/Makefile.micaz
@@ -45,6 +45,6 @@ ifneq ($(strip $(HAVE_PRGBOARD_FILE)), )
   include $(PRGBOARD_FILE)
 endif 
 
-MODULES += core/net core/net/ip core/net/ipv6 core/net/ipv4 core/net/rime \
-           core/net/mac core/net/rpl core/net/mac/cxmac \
+MODULES += core/net \
+           core/net/mac core/net/mac/cxmac core/net/mac/sicslowmac \
            core/net/llsec dev/cc2420

--- a/platform/micaz/contiki-conf.h
+++ b/platform/micaz/contiki-conf.h
@@ -49,9 +49,9 @@
 
 
 #if UIP_CONF_IPV6
-#define WITH_UIP6 1
+#define UIP_CONF_IPV6 1
 #endif
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
 //#define NETSTACK_CONF_MAC     csma_driver
@@ -65,7 +65,7 @@
 #define RIME_CONF_NO_POLITE_ANNOUCEMENTS 0
 #define CXMAC_CONF_ANNOUNCEMENTS         0
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
 /* Network setup for non-IPv6 (rime). */
 
@@ -86,7 +86,7 @@
 
 #define COLLECT_NBR_TABLE_CONF_MAX_NEIGHBORS      32
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define PACKETBUF_CONF_ATTRS_INLINE 1
 
@@ -115,7 +115,7 @@
 #define PROCESS_CONF_NUMEVENTS 8
 #define PROCESS_CONF_STATS 1
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -156,14 +156,14 @@
 #endif /* SICSLOWPAN_CONF_FRAG */
 #define SICSLOWPAN_CONF_CONVENTIONAL_MAC	1
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 #define UIP_CONF_IP_FORWARD      1
 #define UIP_CONF_BUFFER_SIZE     128
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define UIP_CONF_ICMP_DEST_UNREACH 1
 
-#if !WITH_UIP && !WITH_UIP6
+#if !UIP_CONF_IPV4 && !UIP_CONF_IPV6
 #define QUEUEBUF_CONF_NUM          8
 #else
 #define QUEUEBUF_CONF_NUM          4

--- a/platform/micaz/contiki-micaz-main.c
+++ b/platform/micaz/contiki-micaz-main.c
@@ -63,12 +63,12 @@ init_usart(void)
   rs232_init(RS232_PORT_0, USART_BAUD_115200,
              USART_PARITY_NONE | USART_STOP_BITS_1 | USART_DATA_BITS_8);
 
-#if WITH_UIP || WITH_UIP6
+#if UIP_CONF_IPV4 || UIP_CONF_IPV6
  // slip_arch_init(USART_BAUD_115200);
     rs232_redirect_stdout(RS232_PORT_0);
 #else
   rs232_redirect_stdout(RS232_PORT_0);
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/micaz/init-net.c
+++ b/platform/micaz/init-net.c
@@ -53,11 +53,11 @@
 #include "dev/ds2401.h"
 #include "sys/node-id.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
 #include "net/ip/uip.h"
 #include "net/ipv4/uip-fw.h"
 #include "net/uip-fw-drv.h"
@@ -69,7 +69,7 @@ static struct uip_fw_netif meshif =
 
 static uint8_t is_gateway;
 
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 #define UIP_OVER_MESH_CHANNEL 8
 
@@ -102,7 +102,7 @@ set_rime_addr(void)
 }
 
 /*--------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 static void
 set_gateway(void)
 {
@@ -117,7 +117,7 @@ set_gateway(void)
     is_gateway = 1;
   }
 }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 void
 init_net(void)
@@ -140,7 +140,7 @@ init_net(void)
     cc2420_set_pan_addr(IEEE802154_PANID, shortaddr, longaddr);
   }
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   memcpy(&uip_lladdr.addr, ds2401_id, sizeof(uip_lladdr.addr));
   /* Setup nullmac-like MAC for 802.15.4 */
   /* sicslowpan_init(sicslowmac_init(&cc2420_driver)); */
@@ -187,7 +187,7 @@ init_net(void)
            ipaddr.u8[7 * 2], ipaddr.u8[7 * 2 + 1]);
   }
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
@@ -198,10 +198,10 @@ init_net(void)
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0? 1:
                          NETSTACK_RDC.channel_check_interval()),
          CC2420_CONF_CHANNEL);
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
   uip_ipaddr_t hostaddr, netmask;
  
   uip_init();
@@ -235,7 +235,7 @@ init_net(void)
   uip_over_mesh_init(UIP_OVER_MESH_CHANNEL);
   printf_P(PSTR("uIP started with IP address %d.%d.%d.%d\n"),
 	       uip_ipaddr_to_quad(&hostaddr));
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
   
   

--- a/platform/minimal-net/Makefile.minimal-net
+++ b/platform/minimal-net/Makefile.minimal-net
@@ -29,4 +29,4 @@ endif
 CONTIKI_CPU=$(CONTIKI)/cpu/native
 include $(CONTIKI)/cpu/native/Makefile.native
 
-MODULES+=core/net/ip core/net/ipv4 core/net core/net/ipv6 core/net/rime
+MODULES+=core/net

--- a/platform/minimal-net/contiki-main.c
+++ b/platform/minimal-net/contiki-main.c
@@ -54,9 +54,17 @@
 #endif /* __CYGWIN__ */
 
 #ifdef __CYGWIN__
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
 PROCINIT(&etimer_process, &tcpip_process, &wpcap_process, &serial_line_process);
+#else
+PROCINIT(&etimer_process, &wpcap_process, &serial_line_process);
+#endif
 #else /* __CYGWIN__ */
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
 PROCINIT(&etimer_process, &tapdev_process, &tcpip_process, &serial_line_process);
+#else
+PROCINIT(&etimer_process, &tapdev_process, &serial_line_process);
+#endif
 #endif /* __CYGWIN__ */
 
 #if RPL_BORDER_ROUTER

--- a/platform/native/Makefile.native
+++ b/platform/native/Makefile.native
@@ -6,10 +6,6 @@ ifeq ($(HOST_OS),Darwin)
   AROPTS = rc
 endif
 
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
-endif
-
 CONTIKI_TARGET_DIRS = . dev ctk
 CONTIKI_TARGET_MAIN = ${addprefix $(OBJECTDIR)/,contiki-main.o}
 
@@ -23,7 +19,7 @@ TARGET_LIBFILES = /lib/w32api/libws2_32.a /lib/w32api/libiphlpapi.a
 else
 CONTIKI_TARGET_SOURCEFILES += tapdev-drv.c
 #math
-ifneq ($(UIP_CONF_IPV6),1)
+ifneq ($(CONTIKI_WITH_IPV6),1)
 CONTIKI_TARGET_SOURCEFILES += tapdev.c
 else
 CONTIKI_TARGET_SOURCEFILES += tapdev6.c
@@ -46,5 +42,4 @@ CURSES_LIBS ?= -lncurses
 
 TARGET_LIBFILES += $(CURSES_LIBS)
 
-MODULES+=core/net/ip core/net/ipv4 core/net core/net/ipv6 core/net/rime \
-         core/net/mac core/net/rpl core/ctk core/net/llsec
+MODULES+=core/net core/net/mac core/ctk core/net/llsec

--- a/platform/native/contiki-main.c
+++ b/platform/native/contiki-main.c
@@ -55,9 +55,9 @@
 #include "dev/pir-sensor.h"
 #include "dev/vib-sensor.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #include "net/rime/rime.h"
 
@@ -202,7 +202,7 @@ main(int argc, char **argv)
   netstack_init();
   printf("MAC %s RDC %s NETWORK %s\n", NETSTACK_MAC.name, NETSTACK_RDC.name, NETSTACK_NETWORK.name);
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   queuebuf_init();
 
   memcpy(&uip_lladdr.addr, serial_id, sizeof(uip_lladdr.addr));
@@ -225,7 +225,7 @@ main(int argc, char **argv)
 
     printf("%02x%02x\n", lladdr->ipaddr.u8[14], lladdr->ipaddr.u8[15]);
   }
-#else
+#elif UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
 #endif
 

--- a/platform/seedeye/Makefile.seedeye
+++ b/platform/seedeye/Makefile.seedeye
@@ -6,10 +6,6 @@ ifdef SEEDEYE_ID
 CFLAGS += -DSEEDEYE_ID=${SEEDEYE_ID}
 endif
 
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
-endif
-
 CONTIKI_TARGET_DIRS = . dev dev/mrf24j40 apps net
 CONTIKI_TARGET_MAIN = ${addprefix $(OBJECTDIR)/,contiki-main.o}
 

--- a/platform/seedeye/contiki-conf.h
+++ b/platform/seedeye/contiki-conf.h
@@ -69,7 +69,7 @@ typedef uint32_t rtimer_clock_t;
 #define ENERGEST_CONF_ON 1
 #endif /* ENERGEST_CONF_ON */
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 #define NETSTACK_CONF_NETWORK                   sicslowpan_driver
 #define NETSTACK_CONF_FRAMER                    framer_802154
 #define NETSTACK_CONF_MAC                       nullmac_driver
@@ -87,7 +87,7 @@ typedef uint32_t rtimer_clock_t;
 
 #define RDC_CONF_HARDWARE_CSMA                  1
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 #define UIP_CONF_ROUTER                         1
 #ifndef UIP_CONF_IPV6_RPL
 #define UIP_CONF_IPV6_RPL                       1

--- a/platform/seedeye/init-net.c
+++ b/platform/seedeye/init-net.c
@@ -73,7 +73,7 @@ init_net(uint8_t node_id)
   uint16_t shortaddr;
   uint64_t longaddr;
   linkaddr_t addr;
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   uip_ds6_addr_t *lladdr;
   uip_ipaddr_t ipaddr;
 #endif
@@ -135,7 +135,7 @@ init_net(uint8_t node_id)
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0 ? 1 :
                          NETSTACK_RDC.channel_check_interval()), RF_CHANNEL);
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 
 #if LINKADDR_CONF_SIZE == 2
   memset(&uip_lladdr.addr, 0, sizeof(uip_lladdr.addr));
@@ -146,7 +146,9 @@ init_net(uint8_t node_id)
   memcpy(&uip_lladdr.addr, &longaddr, sizeof(uip_lladdr.addr));
 #endif
 
+#if UIP_CONF_IPV6 || UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
+#endif
 
   lladdr = uip_ds6_get_link_local(-1);
 

--- a/platform/sensinode/Makefile.sensinode
+++ b/platform/sensinode/Makefile.sensinode
@@ -46,7 +46,7 @@ CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
 CLEAN += *.sensinode
 
-ifeq ($(UIP_CONF_IPV6),1)
+ifeq ($(CONTIKI_WITH_IPV6),1)
   ifeq ($(OFFSET_FIRMWARE),1)
     CFLAGS += -DDISCO_ENABLED=1
     CONTIKI_TARGET_SOURCEFILES += disco.c
@@ -88,5 +88,5 @@ include $(CONTIKI)/cpu/cc2430/Makefile.cc2430
 
 contiki-$(TARGET).a:# $(addprefix $(OBJECTDIR)/,symbols.rel)
 
-MODULES += core/net/ipv6 core/net/ip core/net/rime core/net core/net/mac core/net/rpl \
+MODULES += core/net core/net/mac \
            core/net/llsec

--- a/platform/sky/Makefile.common
+++ b/platform/sky/Makefile.common
@@ -10,10 +10,6 @@ ifndef CONTIKI_TARGET_MAIN
 CONTIKI_TARGET_MAIN = contiki-sky-main.c
 endif
 
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
-endif
-
 ifdef IAR
 CFLAGS += -D__MSP430F1611__=1 -e --vla -Ohz --multiplier=16s --core=430 --double=32
 CFLAGSNO = --dlib_config "$(IAR_PATH)/LIB/DLIB/dl430fn.h" $(CFLAGSWERROR)

--- a/platform/sky/Makefile.sky
+++ b/platform/sky/Makefile.sky
@@ -10,8 +10,8 @@ endif
 
 include $(CONTIKI)/platform/sky/Makefile.common
 
-MODULES += core/net/ipv6 core/net/ipv4 core/net/rime core/net/mac \
-           core/net core/net/ip core/net/rpl \
+MODULES += core/net/mac \
+           core/net \
            core/net/mac/contikimac core/net/mac/cxmac \
            core/net/llsec core/net/llsec/noncoresec \
            dev/cc2420 dev/sht11 dev/ds2411

--- a/platform/sky/contiki-conf.h
+++ b/platform/sky/contiki-conf.h
@@ -39,7 +39,7 @@
 #define XMAC_CONF_COMPOWER               1
 #define CXMAC_CONF_COMPOWER              1
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
 
@@ -56,7 +56,7 @@
 #define QUEUEBUF_CONF_NUM                8
 #endif
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
 /* Network setup for non-IPv6 (rime). */
 
@@ -85,7 +85,7 @@
 #define CC2420_CONF_SFD_TIMESTAMPS       1
 #endif /* TIMESYNCH_CONF_ENABLED */
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define PACKETBUF_CONF_ATTRS_INLINE 1
 
@@ -131,7 +131,7 @@
 #define PROCESS_CONF_STATS 1
 /*#define PROCESS_CONF_FASTPOLL    4*/
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -183,10 +183,10 @@
 #ifndef SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS
 #define SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS   5
 #endif /* SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS */
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 #define UIP_CONF_IP_FORWARD      1
 #define UIP_CONF_BUFFER_SIZE     108
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define UIP_CONF_ICMP_DEST_UNREACH 1
 

--- a/platform/sky/contiki-sky-main.c
+++ b/platform/sky/contiki-sky-main.c
@@ -43,9 +43,9 @@
 #include "net/netstack.h"
 #include "net/mac/frame802154.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #include "net/rime/rime.h"
 
@@ -72,11 +72,11 @@ static struct timer mgt_timer;
 #endif
 extern int msp430_dco_required;
 
-#ifndef WITH_UIP
-#define WITH_UIP 0
+#ifndef UIP_CONF_IPV4
+#define UIP_CONF_IPV4 0
 #endif
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
 #include "net/ip/uip.h"
 #include "net/ipv4/uip-fw.h"
 #include "net/ipv4/uip-fw-drv.h"
@@ -86,12 +86,12 @@ static struct uip_fw_netif slipif =
 static struct uip_fw_netif meshif =
   {UIP_FW_NETIF(172,16,0,0, 255,255,0,0, uip_over_mesh_send)};
 
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 #define UIP_OVER_MESH_CHANNEL 8
-#if WITH_UIP
+#if UIP_CONF_IPV4
 static uint8_t is_gateway;
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 #ifdef EXPERIMENT_SETUP
 #include "experiment-setup.h"
@@ -172,7 +172,7 @@ print_processes(struct process * const processes[])
 }
 #endif /* !PROCESS_CONF_NO_PROCESS_NAMES */
 /*--------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 static void
 set_gateway(void)
 {
@@ -187,7 +187,7 @@ set_gateway(void)
     is_gateway = 1;
   }
 }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 static void
 start_autostart_processes()
@@ -198,7 +198,7 @@ start_autostart_processes()
   autostart_start(autostart_processes);
 }
 /*---------------------------------------------------------------------------*/
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 static void
 start_uip6()
 {
@@ -235,16 +235,16 @@ start_uip6()
            ipaddr.u8[7 * 2], ipaddr.u8[7 * 2 + 1]);
   }
 }
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 /*---------------------------------------------------------------------------*/
 static void
 start_network_layer()
 {
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   start_uip6();
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
   start_autostart_processes();
-  /* To support link layer security in combination with WITH_UIP and
+  /* To support link layer security in combination with UIP_CONF_IPV4 and
    * TIMESYNCH_CONF_ENABLED further things may need to be moved here */
 }
 /*---------------------------------------------------------------------------*/
@@ -315,9 +315,9 @@ main(int argc, char **argv)
 
   ctimer_init();
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
   slip_arch_init(BAUD2UBR(115200));
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
   init_platform();
 
@@ -350,7 +350,7 @@ main(int argc, char **argv)
 	 ds2411_id[0], ds2411_id[1], ds2411_id[2], ds2411_id[3],
 	 ds2411_id[4], ds2411_id[5], ds2411_id[6], ds2411_id[7]);*/
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   memcpy(&uip_lladdr.addr, ds2411_id, sizeof(uip_lladdr.addr));
   /* Setup nullmac-like MAC for 802.15.4 */
 /*   sicslowpan_init(sicslowmac_init(&cc2420_driver)); */
@@ -368,7 +368,7 @@ main(int argc, char **argv)
          CC2420_CONF_CHANNEL,
          CC2420_CONF_CCA_THRESH);
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
@@ -379,9 +379,9 @@ main(int argc, char **argv)
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0? 1:
                          NETSTACK_RDC.channel_check_interval()),
          CC2420_CONF_CHANNEL);
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
-#if !WITH_UIP && !WITH_UIP6
+#if !UIP_CONF_IPV4 && !UIP_CONF_IPV6
   uart1_set_input(serial_line_input_byte);
   serial_line_init();
 #endif
@@ -393,7 +393,7 @@ main(int argc, char **argv)
   timesynch_set_authority_level((linkaddr_node_addr.u8[0] << 4) + 16);
 #endif /* TIMESYNCH_CONF_ENABLED */
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
   process_start(&uip_fw_process, NULL);	/* Start IP output */
   process_start(&slip_process, NULL);
@@ -420,7 +420,7 @@ main(int argc, char **argv)
     PRINTF("uIP started with IP address %d.%d.%d.%d\n",
 	   uip_ipaddr_to_quad(&hostaddr));
   }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
   watchdog_start();
 

--- a/platform/stm32test/contiki-conf.h
+++ b/platform/stm32test/contiki-conf.h
@@ -6,7 +6,7 @@
 #define CCIF
 #define CLIF
 
-#define WITH_UIP 1
+#define UIP_CONF_IPV4 1
 #define WITH_ASCII 1
 
 #define CLOCK_CONF_SECOND 100

--- a/platform/win32/Makefile.win32
+++ b/platform/win32/Makefile.win32
@@ -41,7 +41,7 @@ CONTIKI_TARGET_SOURCEFILES = contiki-main.c clock.c cfs-win32-dir.c ctk-console.
 CONTIKI_SOURCEFILES += $(CTK) cfs-posix.c ctk-conio.c wpcap.c wpcap-drv.c \
                        $(CONTIKI_TARGET_SOURCEFILES)
 
-MODULES += core/ctk core/net/ip core/net/ipv4 core/net/ipv6
+MODULES += core/ctk
 
 # Define the CPU directory
 

--- a/platform/wismote/Makefile.wismote
+++ b/platform/wismote/Makefile.wismote
@@ -18,10 +18,6 @@ ifndef CONTIKI_TARGET_MAIN
 CONTIKI_TARGET_MAIN = contiki-wismote-main.c
 endif
 
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
-endif
-
 ifdef IAR
 CFLAGS += -D__MSP430F5437__=1 -e --vla -Ohz --multiplier=32 --multiplier_location=4C0 --hw_workaround=CPU40 --core=430X --double=32
 else
@@ -54,7 +50,7 @@ contiki-$(TARGET).a: ${addprefix $(OBJECTDIR)/,symbols.o}
 %.upload-clean: %.hex
 	msp430flasher -n msp430x5437 -w $< -v -z [VCC]
 
-MODULES += core/net core/net/ip core/net/ipv6 core/net/ipv4 core/net/mac \
-           core/net/rime core/net/mac/contikimac core/net/rpl \
+MODULES += core/net core/net/mac \
+           core/net/mac/contikimac \
            core/net/llsec \
            dev/cc2520 dev/sht11

--- a/platform/wismote/contiki-conf.h
+++ b/platform/wismote/contiki-conf.h
@@ -33,7 +33,7 @@
 
 #define NULLRDC_CONF_802154_AUTOACK      1
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
 
@@ -50,7 +50,7 @@
 #define QUEUEBUF_CONF_NUM                8
 #endif
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
 /* Network setup for non-IPv6 (rime). */
 
@@ -83,7 +83,7 @@
 #define CC2520_CONF_SFD_TIMESTAMPS       1
 #endif /* TIMESYNCH_CONF_ENABLED */
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define PACKETBUF_CONF_ATTRS_INLINE 1
 
@@ -119,7 +119,7 @@
 #define PROCESS_CONF_STATS 1
 /*#define PROCESS_CONF_FASTPOLL    4*/
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -170,10 +170,10 @@
 #ifndef SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS
 #define SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS   5
 #endif /* SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS */
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 #define UIP_CONF_IP_FORWARD      1
 #define UIP_CONF_BUFFER_SIZE     108
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define UIP_CONF_ICMP_DEST_UNREACH 1
 

--- a/platform/wismote/contiki-wismote-main.c
+++ b/platform/wismote/contiki-wismote-main.c
@@ -44,9 +44,9 @@
 #include "net/netstack.h"
 #include "net/mac/frame802154.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #include "net/rime/rime.h"
 
@@ -66,11 +66,11 @@
 extern const struct uip_router UIP_ROUTER_MODULE;
 #endif /* UIP_CONF_ROUTER */
 
-#ifndef WITH_UIP
-#define WITH_UIP 0
+#ifndef UIP_CONF_IPV4
+#define UIP_CONF_IPV4 0
 #endif
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
 #include "net/ip/uip.h"
 #include "net/ipv4/uip-fw.h"
 #include "net/uip-fw-drv.h"
@@ -80,12 +80,12 @@ static struct uip_fw_netif slipif =
 static struct uip_fw_netif meshif =
   {UIP_FW_NETIF(172,16,0,0, 255,255,0,0, uip_over_mesh_send)};
 
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 #define UIP_OVER_MESH_CHANNEL 8
-#if WITH_UIP
+#if UIP_CONF_IPV4
 static uint8_t is_gateway;
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 #ifdef EXPERIMENT_SETUP
 #include "experiment-setup.h"
@@ -172,7 +172,7 @@ print_processes(struct process * const processes[])
 }
 #endif /* !PROCESS_CONF_NO_PROCESS_NAMES */
 /*--------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 static void
 set_gateway(void)
 {
@@ -187,7 +187,7 @@ set_gateway(void)
     is_gateway = 1;
   }
 }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 int
 main(int argc, char **argv)
@@ -206,9 +206,9 @@ main(int argc, char **argv)
 
   uart1_init(115200); /* Must come before first printf */
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
   slip_arch_init(115200);
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
   clock_wait(1);
 
@@ -283,7 +283,7 @@ main(int argc, char **argv)
     printf("Node id is not set.\n");
   }
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   /* memcpy(&uip_lladdr.addr, ds2411_id, sizeof(uip_lladdr.addr)); */
   memcpy(&uip_lladdr.addr, linkaddr_node_addr.u8,
          UIP_LLADDR_LEN > LINKADDR_SIZE ? LINKADDR_SIZE : UIP_LLADDR_LEN);
@@ -333,7 +333,7 @@ main(int argc, char **argv)
            ipaddr.u8[7 * 2], ipaddr.u8[7 * 2 + 1]);
   }
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
@@ -344,9 +344,9 @@ main(int argc, char **argv)
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0? 1:
                          NETSTACK_RDC.channel_check_interval()),
          RF_CHANNEL);
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
-#if !WITH_UIP && !WITH_UIP6
+#if !UIP_CONF_IPV4 && !UIP_CONF_IPV6
   uart1_set_input(serial_line_input_byte);
   serial_line_init();
 #endif
@@ -358,7 +358,7 @@ main(int argc, char **argv)
   timesynch_set_authority_level((linkaddr_node_addr.u8[0] << 4) + 16);
 #endif /* TIMESYNCH_CONF_ENABLED */
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
   process_start(&uip_fw_process, NULL);	/* Start IP output */
   process_start(&slip_process, NULL);
@@ -385,7 +385,7 @@ main(int argc, char **argv)
     printf("uIP started with IP address %d.%d.%d.%d\n",
            uip_ipaddr_to_quad(&hostaddr));
   }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
   energest_init();
   ENERGEST_ON(ENERGEST_TYPE_CPU);

--- a/platform/z1/Makefile.common
+++ b/platform/z1/Makefile.common
@@ -26,10 +26,6 @@ ifndef CONTIKI_TARGET_MAIN
 CONTIKI_TARGET_MAIN = contiki-z1-main.c
 endif
 
-ifeq ($(UIP_CONF_IPV6),1)
-CFLAGS += -DWITH_UIP6=1
-endif
-
 ifdef nodemac
 CFLAGS += -DMACID=$(nodemac)
 endif

--- a/platform/z1/Makefile.z1
+++ b/platform/z1/Makefile.z1
@@ -9,7 +9,7 @@ ifeq ($(ZOLERTIA_Z1SP),1)
 include $(CONTIKI)/platform/z1/Makefile.z1sp
 endif
 
-MODULES += core/net core/net/ip core/net/ipv6 core/net/ipv4 core/net/rpl \
-           core/net/rime core/net/mac core/net/mac/contikimac \
+MODULES += core/net \
+           core/net/mac core/net/mac/contikimac \
            core/net/llsec \
            dev/cc2420 dev/sht11

--- a/platform/z1/contiki-conf.h
+++ b/platform/z1/contiki-conf.h
@@ -37,7 +37,7 @@
 #define XMAC_CONF_COMPOWER          1
 #define CXMAC_CONF_COMPOWER         1
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 
 /* Network setup for IPv6 */
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
@@ -61,7 +61,7 @@
 #define QUEUEBUF_CONF_NUM                4 
 
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
 /* Network setup for non-IPv6 (rime). */
 
@@ -87,7 +87,7 @@
 
 #define QUEUEBUF_CONF_NUM          8
 
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define PACKETBUF_CONF_ATTRS_INLINE 1
 
@@ -130,7 +130,7 @@
 
 #define UART0_CONF_TX_WITH_INTERRUPT 0 // So far, printfs without interrupt.
 
-#ifdef WITH_UIP6
+#ifdef UIP_CONF_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -169,10 +169,10 @@
 #endif /* SICSLOWPAN_CONF_FRAG */
 #define SICSLOWPAN_CONF_CONVENTIONAL_MAC	1
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 #define UIP_CONF_IP_FORWARD      1
 #define UIP_CONF_BUFFER_SIZE     108
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #define UIP_CONF_ICMP_DEST_UNREACH 1
 

--- a/platform/z1/contiki-z1-main.c
+++ b/platform/z1/contiki-z1-main.c
@@ -47,9 +47,9 @@
 #include "dev/adxl345.h"
 #include "sys/clock.h"
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
 #include "net/rime/rime.h"
 
@@ -70,11 +70,11 @@ extern unsigned char node_mac[8];
 static struct timer mgt_timer;
 #endif
 
-#ifndef WITH_UIP
-#define WITH_UIP 0
+#ifndef UIP_CONF_IPV4
+#define UIP_CONF_IPV4 0
 #endif
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
 #include "net/ip/uip.h"
 #include "net/ipv4/uip-fw.h"
 #include "net/uip-fw-drv.h"
@@ -84,12 +84,12 @@ static struct uip_fw_netif slipif =
 static struct uip_fw_netif meshif =
 { UIP_FW_NETIF(172, 16, 0, 0, 255, 255, 0, 0, uip_over_mesh_send) };
 
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 #define UIP_OVER_MESH_CHANNEL 8
-#if WITH_UIP
+#if UIP_CONF_IPV4
 static uint8_t is_gateway;
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
 #ifdef EXPERIMENT_SETUP
 #include "experiment-setup.h"
@@ -172,7 +172,7 @@ print_processes(struct process *const processes[])
   putchar('\n');
 }
 /*--------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 static void
 set_gateway(void)
 {
@@ -187,7 +187,7 @@ set_gateway(void)
     is_gateway = 1;
   }
 }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 int
 main(int argc, char **argv)
@@ -203,9 +203,9 @@ main(int argc, char **argv)
   clock_wait(100);
 
   uart0_init(BAUD2UBR(115200)); /* Must come before first printf */
-#if WITH_UIP
+#if UIP_CONF_IPV4
   slip_arch_init(BAUD2UBR(115200));
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
   xmem_init();
 
@@ -308,7 +308,7 @@ main(int argc, char **argv)
     PRINTF("Node id not set\n");
   }
 
-#if WITH_UIP6
+#if UIP_CONF_IPV6
   memcpy(&uip_lladdr.addr, node_mac, sizeof(uip_lladdr.addr));
   /* Setup nullmac-like MAC for 802.15.4 */
 /*   sicslowpan_init(sicslowmac_init(&cc2420_driver)); */
@@ -356,7 +356,7 @@ main(int argc, char **argv)
            ipaddr.u8[7 * 2], ipaddr.u8[7 * 2 + 1]);
   }
 
-#else /* WITH_UIP6 */
+#else /* UIP_CONF_IPV6 */
 
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
@@ -367,9 +367,9 @@ main(int argc, char **argv)
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0 ? 1 :
                          NETSTACK_RDC.channel_check_interval()),
          CC2420_CONF_CHANNEL);
-#endif /* WITH_UIP6 */
+#endif /* UIP_CONF_IPV6 */
 
-#if !WITH_UIP && !WITH_UIP6
+#if !UIP_CONF_IPV4 && !UIP_CONF_IPV6
   uart0_set_input(serial_line_input_byte);
   serial_line_init();
 #endif
@@ -381,7 +381,7 @@ main(int argc, char **argv)
   timesynch_set_authority_level(linkaddr_node_addr.u8[0]);
 #endif /* TIMESYNCH_CONF_ENABLED */
 
-#if WITH_UIP
+#if UIP_CONF_IPV4
   process_start(&tcpip_process, NULL);
   process_start(&uip_fw_process, NULL); /* Start IP output */
   process_start(&slip_process, NULL);
@@ -408,7 +408,7 @@ main(int argc, char **argv)
     printf("uIP started with IP address %d.%d.%d.%d\n",
            uip_ipaddr_to_quad(&hostaddr));
   }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 
   energest_init();
   ENERGEST_ON(ENERGEST_TYPE_CPU);

--- a/regression-tests/04-rime/code/Makefile
+++ b/regression-tests/04-rime/code/Makefile
@@ -2,4 +2,5 @@ CONTIKI = ../../..
 
 all: trickle-node
 
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/regression-tests/11-ipv6/code/receiver/Makefile
+++ b/regression-tests/11-ipv6/code/receiver/Makefile
@@ -1,6 +1,6 @@
 CONTIKI=../../../..
 
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL -DPROJECT_CONF_H=\"project-conf.h\"
+CFLAGS+= -DPROJECT_CONF_H=\"project-conf.h\"
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/regression-tests/11-ipv6/code/sender/Makefile
+++ b/regression-tests/11-ipv6/code/sender/Makefile
@@ -1,6 +1,6 @@
 CONTIKI=../../../..
 
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL -DPROJECT_CONF_H=\"project-conf.h\"
+CFLAGS+= -DPROJECT_CONF_H=\"project-conf.h\"
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/regression-tests/12-rpl/code/Makefile
+++ b/regression-tests/12-rpl/code/Makefile
@@ -1,9 +1,7 @@
 all: sender-node receiver-node root-node
 CONTIKI=../../..
 
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
 CFLAGS+=-DPROJECT_CONF_H=\"project-conf.h\"
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/regression-tests/17-slip-radio/code/Makefile
+++ b/regression-tests/17-slip-radio/code/Makefile
@@ -2,8 +2,5 @@ all: wait-dag
 APPS=servreg-hack
 CONTIKI=../../..
 
-WITH_UIP6=1
-UIP_CONF_IPV6=1
-CFLAGS+= -DUIP_CONF_IPV6_RPL
-
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/tools/release-tools/compile-platforms/Makefile.platform
+++ b/tools/release-tools/compile-platforms/Makefile.platform
@@ -3,7 +3,9 @@ CONTIKI = ../../../..
 APPS=serial-shell webserver telnetd
 
 ifeq ($(TARGET), avr-raven)
-  UIP_CONF_IPV6=1
+  CONTIKI_WITH_IPV6 = 1
+else
+  CONTIKI_WITH_RIME = 1
 endif
 
 include $(CONTIKI)/Makefile.include

--- a/tools/sky/uip6-bridge/Makefile
+++ b/tools/sky/uip6-bridge/Makefile
@@ -6,8 +6,7 @@ CONTIKI=../../..
 endif
 endif
 
-DEFINES=WITH_UIP6=1,WITH_SLIP=1,PROJECT_CONF_H=\"bridge-conf.h\"
-UIP_CONF_IPV6=1
+DEFINES=WITH_SLIP=1,PROJECT_CONF_H=\"bridge-conf.h\"
 
 ifndef TARGET
 TARGET=sky
@@ -22,6 +21,7 @@ upload: uip6-bridge-tap.ihex
 	cp $< $(IHEXFILE)
 	$(MAKE) sky-u.$(subst /,-,$(word $(MOTE), $(MOTES)))
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 ../../tapslip6: ../../tapslip6.c

--- a/tools/sky/uip6-bridge/dev/slip.c
+++ b/tools/sky/uip6-bridge/dev/slip.c
@@ -100,7 +100,7 @@ slip_set_tcpip_input_callback(void (*c)(void))
   tcpip_input_callback = c;
 }
 /*---------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 uint8_t
 slip_send(void)
 {
@@ -129,7 +129,7 @@ slip_send(void)
 
   return UIP_FW_OK;
 }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 uint8_t
 slip_write(const void *_ptr, int len)

--- a/tools/stm32w/uip6_bridge/Makefile
+++ b/tools/stm32w/uip6_bridge/Makefile
@@ -7,7 +7,6 @@ endif
 endif
 
 DEFINES=PROJECT_CONF_H=\"bridge-conf.h\"
-UIP_CONF_IPV6=1
 
 ifndef TARGET
 TARGET=mbxxx
@@ -18,4 +17,5 @@ PROJECT_SOURCEFILES = fakeuip.c sicslow_ethernet.c slip.c
 
 all:	uip6-bridge-tap
 
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/tools/stm32w/uip6_bridge/dev/slip.c
+++ b/tools/stm32w/uip6_bridge/dev/slip.c
@@ -115,7 +115,7 @@ slip_set_tcpip_input_callback(void (*c)(void))
 	tcpip_input_callback = c;
 }
 /*---------------------------------------------------------------------------*/
-#if WITH_UIP
+#if UIP_CONF_IPV4
 uint8_t
 slip_send(void)
 {
@@ -144,7 +144,7 @@ slip_send(void)
 
 	return UIP_FW_OK;
 }
-#endif /* WITH_UIP */
+#endif /* UIP_CONF_IPV4 */
 /*---------------------------------------------------------------------------*/
 uint8_t
 slip_write(const void *_ptr, int len)


### PR DESCRIPTION
...TH_IPV6, CONTIKI_WITH_IPV4, and CONTIKI_WITH_RIME in makefiles, and UIP_CONF_IPV6, UIP_CONF_IPV4, UIP_CONF_RIME in c code. Now only the stacks that are used are compiled (via makefile MODULES). Make IPv6 the default network stack.
