### PR TITLE
Changed 'data' casting for 'ctk_signal_keypress'.

### DIFF
--- a/core/ctk/ctk-filedialog.c
+++ b/core/ctk/ctk-filedialog.c
@@ -155,14 +155,14 @@ ctk_filedialog_eventhandler(struct ctk_filedialog_state *s,
       }
       return 1; 
     } else if(ev == ctk_signal_keypress) {
-      if((unsigned long)data == CH_CURS_UP) {
+      if((char)(size_t)data == CH_CURS_UP) {
 	clearptr();
 	if(fileptr > 0) {
 	  --fileptr;
 	}
 	showptr();
 	return 1;
-      } else if((unsigned long)data == CH_CURS_DOWN) {
+      } else if((char)(size_t)data == CH_CURS_DOWN) {
 	clearptr();
 	if(fileptr < FILES_HEIGHT - 1) {
 	  ++fileptr;


### PR DESCRIPTION
In these cases data was set as `process_post_synch(window->owner, ctk_signal_keypress, (process_data_t)(size_t)c);` so it seems reasonable to cast "back" to `size_t`. Additionally the comparison can be limited to `char`. See i.e. calcc for reference:

```
if(ev == ctk_signal_keypress) {
  if((char)(size_t)data >= '0' &&
     (char)(size_t)data <= '9') {
```
