### PR TITLE
Enable the root to send back a DAO-ACK

### DIFF
--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -179,9 +179,11 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
 {
   uint8_t *uip_next_hdr;
   int last_uip_ext_len = uip_ext_len;
+  rpl_dag_t *dag;
 
   uip_ext_len = 0;
   uip_next_hdr = &UIP_IP_BUF->proto;
+  dag = rpl_get_dag(&UIP_IP_BUF->destipaddr);
 
   /* Look for routing header */
   while(uip_next_hdr != NULL && *uip_next_hdr != UIP_PROTO_ROUTING) {
@@ -206,8 +208,10 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
     }
   }
 
-  if(uip_next_hdr != NULL && *uip_next_hdr == UIP_PROTO_ROUTING
-      && UIP_RH_BUF->routing_type == RPL_RH_TYPE_SRH) {
+  if((uip_next_hdr != NULL && *uip_next_hdr == UIP_PROTO_ROUTING
+      && UIP_RH_BUF->routing_type == RPL_RH_TYPE_SRH) ||
+     (default_instance->current_dag->rank == ROOT_RANK(default_instance) &&
+      rpl_ns_get_node(dag, &UIP_IP_BUF->destipaddr) != NULL)) {
     /* Routing header found. The next hop should be already copied as the IPv6 destination
      * address, via rpl_process_srh_header. We turn this address into a link-local to enable
      * forwarding to next hop */
@@ -370,6 +374,12 @@ insert_srh_header()
   /* For simplicity, we use cmpri = cmpre */
   cmpri = 15;
   cmpre = 15;
+
+  if(node != NULL && node == root_node) {
+    PRINTF("RPL: SRH no need to insert SRH\n");
+    return 0;
+  }
+
   while(node != NULL && node != root_node) {
 
     rpl_ns_get_node_global_addr(&node_addr, node);
@@ -378,18 +388,18 @@ insert_srh_header()
     cmpri = MIN(cmpri, count_matching_bytes(&node_addr, &UIP_IP_BUF->destipaddr, 16));
     cmpre = cmpri;
 
-    PRINTF("RPL: SRH Hop ");
-    PRINT6ADDR(&node_addr);
-    PRINTF("\n");
+    if(node->parent != root_node) {
+      PRINTF("RPL: SRH Hop ");
+      PRINT6ADDR(&node_addr);
+      PRINTF("\n");
+    } else if(((DEBUG) & DEBUG_PRINT)) {
+      rpl_ns_get_node_global_addr(&node_addr, node);
+      PRINTF("RPL: SRH Next Hop ");
+      PRINT6ADDR(&node_addr);
+      PRINTF("\n");
+    }
     node = node->parent;
     path_len++;
-  }
-
-  if(((DEBUG) & DEBUG_PRINT) && node != NULL) {
-    rpl_ns_get_node_global_addr(&node_addr, node);
-    PRINTF("RPL: SRH Next Hop ");
-    PRINT6ADDR(&node_addr);
-    PRINTF("\n");
   }
 
   /* Extension header length: fixed headers + (n-1) * (16-ComprI) + (16-ComprE)*/

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -393,16 +393,9 @@ insert_srh_header()
     cmpri = MIN(cmpri, count_matching_bytes(&node_addr, &UIP_IP_BUF->destipaddr, 16));
     cmpre = cmpri;
 
-    if(node->parent != root_node) {
-      PRINTF("RPL: SRH Hop ");
-      PRINT6ADDR(&node_addr);
-      PRINTF("\n");
-    } else if(((DEBUG) & DEBUG_PRINT)) {
-      rpl_ns_get_node_global_addr(&node_addr, node);
-      PRINTF("RPL: SRH Next Hop ");
-      PRINT6ADDR(&node_addr);
-      PRINTF("\n");
-    }
+    PRINTF("RPL: SRH Hop ");
+    PRINT6ADDR(&node_addr);
+    PRINTF("\n");
     node = node->parent;
     path_len++;
   }

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -209,13 +209,14 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
     }
   }
 
-  dag = rpl_get_dag(&IP_IP_BUF->destipaddr);
+  dag = rpl_get_dag(&UIP_IP_BUF->destipaddr);
   root_node = rpl_ns_get_node(dag, &dag->dag_id);
   dest_node = rpl_ns_get_node(dag, &UIP_IP_BUF->destipaddr);
 
   if((uip_next_hdr != NULL && *uip_next_hdr == UIP_PROTO_ROUTING
       && UIP_RH_BUF->routing_type == RPL_RH_TYPE_SRH) ||
-     (dest_node != NULL && root_node != NULL && node->parent == root_node)) {
+     (dest_node != NULL && root_node != NULL &&
+      dest_node->parent == root_node)) {
     /* Routing header found or the packet destined for a direct child of the root.
      * The next hop should be already copied as the IPv6 destination
      * address, via rpl_process_srh_header. We turn this address into a link-local to enable

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -180,10 +180,11 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
   uint8_t *uip_next_hdr;
   int last_uip_ext_len = uip_ext_len;
   rpl_dag_t *dag;
+  rpl_ns_node_t *dest_node;
+  rpl_ns_node_t *root_node;
 
   uip_ext_len = 0;
   uip_next_hdr = &UIP_IP_BUF->proto;
-  dag = rpl_get_dag(&UIP_IP_BUF->destipaddr);
 
   /* Look for routing header */
   while(uip_next_hdr != NULL && *uip_next_hdr != UIP_PROTO_ROUTING) {
@@ -208,11 +209,15 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
     }
   }
 
+  dag = rpl_get_dag(&IP_IP_BUF->destipaddr);
+  root_node = rpl_ns_get_node(dag, &dag->dag_id);
+  dest_node = rpl_ns_get_node(dag, &UIP_IP_BUF->destipaddr);
+
   if((uip_next_hdr != NULL && *uip_next_hdr == UIP_PROTO_ROUTING
       && UIP_RH_BUF->routing_type == RPL_RH_TYPE_SRH) ||
-     (default_instance->current_dag->rank == ROOT_RANK(default_instance) &&
-      rpl_ns_get_node(dag, &UIP_IP_BUF->destipaddr) != NULL)) {
-    /* Routing header found. The next hop should be already copied as the IPv6 destination
+     (dest_node != NULL && root_node != NULL && node->parent == root_node)) {
+    /* Routing header found or the packet destined for a direct child of the root.
+     * The next hop should be already copied as the IPv6 destination
      * address, via rpl_process_srh_header. We turn this address into a link-local to enable
      * forwarding to next hop */
     uip_ipaddr_copy(ipaddr, &UIP_IP_BUF->destipaddr);

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -380,7 +380,7 @@ insert_srh_header()
   cmpri = 15;
   cmpre = 15;
 
-  if(node != NULL && node == root_node) {
+  if(node == root_node) {
     PRINTF("RPL: SRH no need to insert SRH\n");
     return 0;
   }

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -1082,6 +1082,7 @@ dao_ack_output(rpl_instance_t *instance, uip_ipaddr_t *dest, uint8_t sequence)
   PRINT6ADDR(dest);
   PRINTF("\n");
 
+  uip_ext_len = 0;
   buffer = UIP_ICMP_PAYLOAD;
 
   buffer[0] = instance->instance_id;

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -731,6 +731,7 @@ dao_input_storing(void)
                        ICMP6_RPL, RPL_CODE_DAO, buffer_length);
       }
       if(flags & RPL_DAO_K_FLAG) {
+        uip_clear_buf();
         dao_ack_output(instance, &dao_sender_addr, sequence);
       }
     }
@@ -787,6 +788,7 @@ fwd_dao:
                      ICMP6_RPL, RPL_CODE_DAO, buffer_length);
     }
     if(flags & RPL_DAO_K_FLAG) {
+      uip_clear_buf();
       dao_ack_output(instance, &dao_sender_addr, sequence);
     }
   }

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -887,6 +887,7 @@ dao_input_nonstoring(void)
   }
 
   if(flags & RPL_DAO_K_FLAG) {
+    uip_clear_buf();
     dao_ack_output(instance, &dao_sender_addr, sequence);
   }
 }
@@ -1082,7 +1083,6 @@ dao_ack_output(rpl_instance_t *instance, uip_ipaddr_t *dest, uint8_t sequence)
   PRINT6ADDR(dest);
   PRINTF("\n");
 
-  uip_ext_len = 0;
   buffer = UIP_ICMP_PAYLOAD;
 
   buffer[0] = instance->instance_id;


### PR DESCRIPTION
I found that the root node did not respond to a DAO with K-bit on. This PR solves the issue.

To test this change, I used `regression-tests/12-rpl/05-rpl-up-and-down-routes.csc` with putting the followings into `code/project-conf.h`.

> #define RPL_CONF_DAO_ACK 1
> #define RPL_CONF_WITH_NON_STORING 1
> #undef RPL_CONF_WITH_STORING
> #define RPL_CONF_WITH_STORING 0
> #undef RPL_CONF_MOP
> #define RPL_CONF_MOP RPL_MOP_NON_STORING