### PR TITLE
Add NULL checks into new_time_source of orchestra-rule-eb-per-time-source.c

### DIFF
--- a/apps/orchestra/orchestra-rule-eb-per-time-source.c
+++ b/apps/orchestra/orchestra-rule-eb-per-time-source.c
@@ -74,8 +74,8 @@ select_packet(uint16_t *slotframe, uint16_t *timeslot)
 static void
 new_time_source(const struct tsch_neighbor *old, const struct tsch_neighbor *new)
 {
-  uint16_t old_ts = get_node_timeslot(&old->addr);
-  uint16_t new_ts = get_node_timeslot(&new->addr);
+  uint16_t old_ts = old != NULL ? get_node_timeslot(&old->addr) : 0xffff;
+  uint16_t new_ts = new != NULL ? get_node_timeslot(&new->addr) : 0xffff;
 
   if(new_ts == old_ts) {
     return;


### PR DESCRIPTION
This PR prevents possible NULL pointer dereferences in `new_time_source()` of `orchestra-rule-eb-per-time-source.c` (cf. https://github.com/contiki-os/contiki/pull/1672#issuecomment-220709017).